### PR TITLE
Add SourceBase.Desktop tray app for rest reminders

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,51 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup>
-    <!-- Test packages -->
-    <PackageVersion Include="Testcontainers.PostgreSQL" Version="4.12.0" />
-    <PackageVersion Include="Testcontainers.Redis" Version="4.12.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
-    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="Shouldly" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
-    <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
-    <PackageVersion Include="BetterStack.Logs.Serilog" Version="1.2.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageVersion Include="FluentValidation" Version="12.1.1" />
-    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
-    <PackageVersion Include="MediatR" Version="14.1.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
-    <PackageVersion Include="AWSSDK.S3" Version="4.0.24.4" />
-    <PackageVersion Include="HtmlAgilityPack" Version="1.11.71" />
-    <PackageVersion Include="SendGrid" Version="9.29.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis"
-      Version="10.0.9" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.8.16" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
-    <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
-    <PackageVersion Include="Serilog.Enrichers.Span" Version="3.1.0" />
-    <PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0" />
-  </ItemGroup>
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+	</PropertyGroup>
+	<ItemGroup>
+		<!-- Test packages -->
+		<PackageVersion Include="Testcontainers.PostgreSQL" Version="4.12.0" />
+		<PackageVersion Include="Testcontainers.Redis" Version="4.12.0" />
+		<PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+		<PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
+		<PackageVersion Include="xunit" Version="2.9.3" />
+		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+		<PackageVersion Include="coverlet.collector" Version="10.0.1" />
+		<PackageVersion Include="Shouldly" Version="4.3.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
+		<PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
+		<PackageVersion Include="BetterStack.Logs.Serilog" Version="1.2.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageVersion Include="FluentValidation" Version="12.1.1" />
+		<PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
+		<PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+		<PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+		<PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
+		<PackageVersion Include="MediatR" Version="14.1.0" />
+		<PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9" />
+		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.9" />
+		<PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
+		<PackageVersion Include="AWSSDK.S3" Version="4.0.24.4" />
+		<PackageVersion Include="HtmlAgilityPack" Version="1.11.71" />
+		<PackageVersion Include="SendGrid" Version="9.29.3" />
+		<PackageVersion Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.9" />
+		<PackageVersion Include="StackExchange.Redis" Version="2.8.16" />
+		<PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+		<PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
+		<PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
+		<PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+		<PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+		<PackageVersion Include="Serilog.Enrichers.Span" Version="3.1.0" />
+		<PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<!-- Modern WPF tray-icon library (NOTIFYICON). Hardcodet.NotifyIcon.Wpf is the classic alternative. -->
+		<PackageVersion Include="H.NotifyIcon.Wpf" Version="2.1.3" />
+		<PackageVersion Include="System.Text.Json" Version="9.0.0" />
+	</ItemGroup>
 </Project>

--- a/SourceBase.Application/Features/HabitLogs/CreateHabitLog.cs
+++ b/SourceBase.Application/Features/HabitLogs/CreateHabitLog.cs
@@ -5,41 +5,47 @@ using SourceBase.Application.Shared.Interfaces;
 
 namespace SourceBase.Application.Features.HabitLogs;
 
-public record CreateHabitLogRequest(string? HabitId, string? HabitName, HabitLogAction Action, DateTime OccurredAt);
+public record HabitLogEntry(string? HabitId, string? HabitName, HabitLogAction Action, DateTime OccurredAt);
 
-public record CreateHabitLogResponse(Guid Id);
+public record CreateHabitLogsRequest(List<HabitLogEntry> Entries);
 
-public class CreateHabitLogEndpoint : IEndpoint
+public record CreateHabitLogsResponse(List<Guid> Ids);
+
+public class CreateHabitLogsEndpoint : IEndpoint
 {
     public const string Route = "habit-logs";
 
     public void MapEndpoint(IEndpointRouteBuilder app) => app
-        .MapPost(Route, ([FromBody] CreateHabitLogRequest request, CreateHabitLogHandler handler, CancellationToken ct) => handler.Handle(request, ct))
+        .MapPost(Route, ([FromBody] CreateHabitLogsRequest request, CreateHabitLogsHandler handler, CancellationToken ct) => handler.Handle(request, ct))
         .WithTags("HabitLogs");
 }
 
-public class CreateHabitLogHandler(IDbContext dbContext, ICurrentUser currentUser) : IRequestHandler<CreateHabitLogRequest, CreateHabitLogResponse>
+public class CreateHabitLogsHandler(IDbContext dbContext, ICurrentUser currentUser) : IRequestHandler<CreateHabitLogsRequest, CreateHabitLogsResponse>
 {
-    public async Task<CreateHabitLogResponse> Handle(CreateHabitLogRequest request, CancellationToken ct)
+    public async Task<CreateHabitLogsResponse> Handle(CreateHabitLogsRequest request, CancellationToken ct)
     {
-        var entry = new HabitLogEntity
-        {
-            UserId = currentUser.UserId,
-            HabitId = request.HabitId,
-            HabitName = request.HabitName,
-            Action = request.Action,
-            OccurredAt = request.OccurredAt,
-        };
-        dbContext.HabitLogs.Add(entry);
+        var entities = request.Entries
+            .Select(e => new HabitLogEntity
+            {
+                UserId = currentUser.UserId,
+                HabitId = e.HabitId,
+                HabitName = e.HabitName,
+                Action = e.Action,
+                OccurredAt = e.OccurredAt,
+            })
+            .ToList();
+
+        dbContext.HabitLogs.AddRange(entities);
         await dbContext.SaveChangesAsync(ct);
-        return new CreateHabitLogResponse(entry.Id);
+        return new CreateHabitLogsResponse(entities.Select(e => e.Id).ToList());
     }
 }
 
-public class CreateHabitLogRequestValidator : AbstractValidator<CreateHabitLogRequest>
+public class CreateHabitLogsRequestValidator : AbstractValidator<CreateHabitLogsRequest>
 {
-    public CreateHabitLogRequestValidator()
+    public CreateHabitLogsRequestValidator()
     {
-        RuleFor(x => x.OccurredAt).NotEmpty();
+        RuleFor(x => x.Entries).NotEmpty();
+        RuleForEach(x => x.Entries).ChildRules(entry => entry.RuleFor(x => x.OccurredAt).NotEmpty());
     }
 }

--- a/SourceBase.Application/Features/HabitLogs/CreateHabitLog.cs
+++ b/SourceBase.Application/Features/HabitLogs/CreateHabitLog.cs
@@ -1,0 +1,45 @@
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using SourceBase.Application.Shared;
+using SourceBase.Application.Shared.Interfaces;
+
+namespace SourceBase.Application.Features.HabitLogs;
+
+public record CreateHabitLogRequest(string? HabitId, string? HabitName, HabitLogAction Action, DateTime OccurredAt);
+
+public record CreateHabitLogResponse(Guid Id);
+
+public class CreateHabitLogEndpoint : IEndpoint
+{
+    public const string Route = "habit-logs";
+
+    public void MapEndpoint(IEndpointRouteBuilder app) => app
+        .MapPost(Route, ([FromBody] CreateHabitLogRequest request, CreateHabitLogHandler handler, CancellationToken ct) => handler.Handle(request, ct))
+        .WithTags("HabitLogs");
+}
+
+public class CreateHabitLogHandler(IDbContext dbContext, ICurrentUser currentUser) : IRequestHandler<CreateHabitLogRequest, CreateHabitLogResponse>
+{
+    public async Task<CreateHabitLogResponse> Handle(CreateHabitLogRequest request, CancellationToken ct)
+    {
+        var entry = new HabitLogEntity
+        {
+            UserId = currentUser.UserId,
+            HabitId = request.HabitId,
+            HabitName = request.HabitName,
+            Action = request.Action,
+            OccurredAt = request.OccurredAt,
+        };
+        dbContext.HabitLogs.Add(entry);
+        await dbContext.SaveChangesAsync(ct);
+        return new CreateHabitLogResponse(entry.Id);
+    }
+}
+
+public class CreateHabitLogRequestValidator : AbstractValidator<CreateHabitLogRequest>
+{
+    public CreateHabitLogRequestValidator()
+    {
+        RuleFor(x => x.OccurredAt).NotEmpty();
+    }
+}

--- a/SourceBase.Application/Features/HabitLogs/CreateHabitLog.cs
+++ b/SourceBase.Application/Features/HabitLogs/CreateHabitLog.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
-using SourceBase.Application.Shared;
 using SourceBase.Application.Shared.Interfaces;
 
 namespace SourceBase.Application.Features.HabitLogs;

--- a/SourceBase.Application/Features/HabitLogs/DeleteHabitLog.cs
+++ b/SourceBase.Application/Features/HabitLogs/DeleteHabitLog.cs
@@ -1,0 +1,31 @@
+using SourceBase.Application.Shared;
+using SourceBase.Application.Shared.Interfaces;
+
+namespace SourceBase.Application.Features.HabitLogs;
+
+public record DeleteHabitLogRequest(Guid Id);
+
+public record DeleteHabitLogResponse(bool Success);
+
+public class DeleteHabitLogEndpoint : IEndpoint
+{
+    public const string Route = "habit-logs/{id:guid}";
+
+    public void MapEndpoint(IEndpointRouteBuilder app) => app
+        .MapDelete(Route, (Guid id, DeleteHabitLogHandler handler, CancellationToken ct) => handler.Handle(new DeleteHabitLogRequest(id), ct))
+        .WithTags("HabitLogs");
+}
+
+public class DeleteHabitLogHandler(IDbContext dbContext, ICurrentUser currentUser) : IRequestHandler<DeleteHabitLogRequest, DeleteHabitLogResponse>
+{
+    public async Task<DeleteHabitLogResponse> Handle(DeleteHabitLogRequest request, CancellationToken ct)
+    {
+        var entry = await dbContext.HabitLogs.FindAsync([request.Id], ct);
+        if (entry == null || entry.UserId != currentUser.UserId)
+            throw new NotFoundException();
+
+        dbContext.HabitLogs.Remove(entry);
+        await dbContext.SaveChangesAsync(ct);
+        return new DeleteHabitLogResponse(true);
+    }
+}

--- a/SourceBase.Application/Features/HabitLogs/GetHabitLogs.cs
+++ b/SourceBase.Application/Features/HabitLogs/GetHabitLogs.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+using SourceBase.Application.Shared;
+using SourceBase.Application.Shared.Interfaces;
+
+namespace SourceBase.Application.Features.HabitLogs;
+
+public record GetHabitLogsRequest(HabitLogAction? Action, DateTime? From, DateTime? To, int? Page, int? Limit, PagingOrder? Order, GetHabitLogsOrderBy? OrderBy)
+    : PagingRequest(Page, Limit, Order, OrderBy?.ToString());
+
+public record GetHabitLogResponse(Guid Id, string? HabitId, string? HabitName, HabitLogAction Action, DateTime OccurredAt, DateTime? CreatedOn);
+
+public class GetHabitLogsEndpoint : IEndpoint
+{
+    public const string Route = "habit-logs";
+
+    public void MapEndpoint(IEndpointRouteBuilder app) => app
+        .MapGet(Route, ([AsParameters] GetHabitLogsRequest request, GetHabitLogsHandler handler, CancellationToken ct) => handler.Handle(request, ct))
+        .WithTags("HabitLogs");
+}
+
+public class GetHabitLogsHandler(IDbContext dbContext, ICurrentUser currentUser) : IRequestHandler<GetHabitLogsRequest, PagingResponse<GetHabitLogResponse>>
+{
+    public async Task<PagingResponse<GetHabitLogResponse>> Handle(GetHabitLogsRequest request, CancellationToken ct)
+    {
+        var logs = await dbContext.HabitLogs
+            .Where(x => x.UserId == currentUser.UserId
+                && (request.Action == null || x.Action == request.Action)
+                && (request.From == null || x.OccurredAt >= request.From)
+                && (request.To == null || x.OccurredAt <= request.To))
+            .PaginateAsync(x => new GetHabitLogResponse(x.Id, x.HabitId, x.HabitName, x.Action, x.OccurredAt, x.CreatedOn), request, ct);
+        return logs;
+    }
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum GetHabitLogsOrderBy { OccurredAt, Action, HabitName, CreatedOn }

--- a/SourceBase.Application/Features/Habits/CreateHabit.cs
+++ b/SourceBase.Application/Features/Habits/CreateHabit.cs
@@ -1,0 +1,36 @@
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using SourceBase.Application.Shared.Interfaces;
+
+namespace SourceBase.Application.Features.Habits;
+
+public record CreateHabitRequest(string Name, string? Icon);
+public record CreateHabitResponse(Guid Id);
+
+public class CreateHabitEndpoint : IEndpoint
+{
+    public const string Route = "habits";
+
+    public void MapEndpoint(IEndpointRouteBuilder app) => app
+        .MapPost(Route, ([FromBody] CreateHabitRequest request, CreateHabitHandler handler, CancellationToken ct) => handler.Handle(request, ct))
+        .WithTags("Habits");
+}
+
+public class CreateHabitHandler(IDbContext dbContext, ICurrentUser currentUser) : IRequestHandler<CreateHabitRequest, CreateHabitResponse>
+{
+    public async Task<CreateHabitResponse> Handle(CreateHabitRequest request, CancellationToken ct)
+    {
+        var habit = new HabitEntity { Name = request.Name, Icon = request.Icon, UserId = currentUser.UserId, IsSystem = false };
+        dbContext.Habits.Add(habit);
+        await dbContext.SaveChangesAsync(ct);
+        return new CreateHabitResponse(habit.Id);
+    }
+}
+
+public class CreateHabitRequestValidator : AbstractValidator<CreateHabitRequest>
+{
+    public CreateHabitRequestValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(100);
+    }
+}

--- a/SourceBase.Application/Features/Habits/DeleteHabit.cs
+++ b/SourceBase.Application/Features/Habits/DeleteHabit.cs
@@ -1,0 +1,31 @@
+using SourceBase.Application.Shared;
+using SourceBase.Application.Shared.Interfaces;
+
+namespace SourceBase.Application.Features.Habits;
+
+public record DeleteHabitRequest(Guid Id);
+public record DeleteHabitResponse(bool Success);
+
+public class DeleteHabitEndpoint : IEndpoint
+{
+    public const string Route = "habits/{id:guid}";
+
+    public void MapEndpoint(IEndpointRouteBuilder app) => app
+        .MapDelete(Route, (Guid id, DeleteHabitHandler handler, CancellationToken ct) => handler.Handle(new DeleteHabitRequest(id), ct))
+        .WithTags("Habits");
+}
+
+public class DeleteHabitHandler(IDbContext dbContext, ICurrentUser currentUser) : IRequestHandler<DeleteHabitRequest, DeleteHabitResponse>
+{
+    public async Task<DeleteHabitResponse> Handle(DeleteHabitRequest request, CancellationToken ct)
+    {
+        var habit = await dbContext.Habits.FindAsync([request.Id], ct);
+        if (habit is null) throw new NotFoundException();
+        if (habit.IsSystem) throw new ForbiddenException();
+        if (habit.UserId != currentUser.UserId) throw new NotFoundException();
+
+        dbContext.Habits.Remove(habit);
+        await dbContext.SaveChangesAsync(ct);
+        return new DeleteHabitResponse(true);
+    }
+}

--- a/SourceBase.Application/Features/Habits/GetHabits.cs
+++ b/SourceBase.Application/Features/Habits/GetHabits.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using SourceBase.Application.Shared.Interfaces;
+
+namespace SourceBase.Application.Features.Habits;
+
+public record GetHabitsRequest;
+public record HabitResponse(Guid Id, string Name, string? Icon, bool IsSystem);
+
+public class GetHabitsEndpoint : IEndpoint
+{
+    public const string Route = "habits";
+
+    public void MapEndpoint(IEndpointRouteBuilder app) => app
+        .MapGet(Route, (GetHabitsHandler handler, CancellationToken ct) => handler.Handle(new GetHabitsRequest(), ct))
+        .WithTags("Habits");
+}
+
+public class GetHabitsHandler(IDbContext dbContext, ICurrentUser currentUser) : IRequestHandler<GetHabitsRequest, List<HabitResponse>>
+{
+    public async Task<List<HabitResponse>> Handle(GetHabitsRequest request, CancellationToken ct) =>
+        await dbContext.Habits
+            .Where(h => h.IsSystem || h.UserId == currentUser.UserId)
+            .OrderBy(h => h.Name)
+            .Select(h => new HabitResponse(h.Id, h.Name, h.Icon, h.IsSystem))
+            .ToListAsync(ct);
+}

--- a/SourceBase.Application/Features/Habits/UpdateHabit.cs
+++ b/SourceBase.Application/Features/Habits/UpdateHabit.cs
@@ -1,0 +1,44 @@
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using SourceBase.Application.Shared;
+using SourceBase.Application.Shared.Interfaces;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace SourceBase.Application.Features.Habits;
+
+public record UpdateHabitRequest([property: SwaggerIgnore][property: FromRoute] Guid Id, string? Name, string? Icon);
+public record UpdateHabitResponse(Guid Id);
+
+public class UpdateHabitEndpoint : IEndpoint
+{
+    public const string Route = "habits/{id:guid}";
+
+    public void MapEndpoint(IEndpointRouteBuilder app) => app
+        .MapPatch(Route, ([FromBody] UpdateHabitRequest body, UpdateHabitHandler handler, CancellationToken ct) => handler.Handle(body, ct))
+        .WithTags("Habits");
+}
+
+public class UpdateHabitHandler(IDbContext dbContext, ICurrentUser currentUser) : IRequestHandler<UpdateHabitRequest, UpdateHabitResponse>
+{
+    public async Task<UpdateHabitResponse> Handle(UpdateHabitRequest request, CancellationToken ct)
+    {
+        var habit = await dbContext.Habits.FindAsync([request.Id], ct);
+        if (habit is null) throw new NotFoundException();
+        if (habit.IsSystem) throw new ForbiddenException();
+        if (habit.UserId != currentUser.UserId) throw new NotFoundException();
+
+        habit.Name = request.Name ?? habit.Name;
+        habit.Icon = request.Icon ?? habit.Icon;
+        await dbContext.SaveChangesAsync(ct);
+        return new UpdateHabitResponse(habit.Id);
+    }
+}
+
+public class UpdateHabitRequestValidator : AbstractValidator<UpdateHabitRequest>
+{
+    public UpdateHabitRequestValidator()
+    {
+        RuleFor(x => x.Id).NotEmpty();
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(100).When(x => x.Name is not null);
+    }
+}

--- a/SourceBase.Application/Shared/Interfaces/IDbContext.cs
+++ b/SourceBase.Application/Shared/Interfaces/IDbContext.cs
@@ -32,5 +32,7 @@ public interface IDbContext
 
     DbSet<GoldPriceEntity> GoldPrices { get; set; }
 
+    DbSet<HabitLogEntity> HabitLogs { get; set; }
+
     Task<int> SaveChangesAsync(CancellationToken ct);
 }

--- a/SourceBase.Application/Shared/Interfaces/IDbContext.cs
+++ b/SourceBase.Application/Shared/Interfaces/IDbContext.cs
@@ -34,5 +34,7 @@ public interface IDbContext
 
     DbSet<HabitLogEntity> HabitLogs { get; set; }
 
+    DbSet<HabitEntity> Habits { get; set; }
+
     Task<int> SaveChangesAsync(CancellationToken ct);
 }

--- a/SourceBase.Desktop/App.xaml
+++ b/SourceBase.Desktop/App.xaml
@@ -1,0 +1,16 @@
+<Application x:Class="SourceBase.Desktop.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:tb="clr-namespace:H.NotifyIcon;assembly=H.NotifyIcon.Wpf"
+             ShutdownMode="OnExplicitShutdown"
+             Startup="OnStartup"
+             Exit="OnExit">
+    <Application.Resources>
+        <ContextMenu x:Key="TrayMenu">
+            <MenuItem Header="Take a break now" Click="OnBreakNow"/>
+            <MenuItem Header="Settings…" Click="OnOpenSettings"/>
+            <Separator/>
+            <MenuItem Header="Exit" Click="OnExitClicked"/>
+        </ContextMenu>
+    </Application.Resources>
+</Application>

--- a/SourceBase.Desktop/App.xaml.cs
+++ b/SourceBase.Desktop/App.xaml.cs
@@ -1,9 +1,10 @@
-using System.Windows;
-using System.Windows.Controls;
-using H.NotifyIcon;
+﻿using H.NotifyIcon;
 using SourceBase.Desktop.Overlay;
 using SourceBase.Desktop.Scheduling;
 using SourceBase.Desktop.Settings;
+using System.Drawing;
+using System.Windows;
+using System.Windows.Controls;
 
 namespace SourceBase.Desktop;
 
@@ -16,6 +17,7 @@ public partial class App : Application
     private TaskbarIcon? _tray;
     private RestScheduler? _scheduler;
     private OverlayWindow? _activeOverlay;
+    private Icon? _trayIcon;
 
     private void OnStartup(object sender, StartupEventArgs e)
     {
@@ -28,11 +30,13 @@ public partial class App : Application
 
         _store.Load();
 
+        _trayIcon = CreateTrayIcon(TrayGlyph.Mug);
+
         _tray = new TaskbarIcon
         {
-            ToolTipText = "SourceBase — rest reminders",
+            ToolTipText = "SourceBase - rest reminders",
             ContextMenu = (ContextMenu)Resources["TrayMenu"],
-            // Icon: ship an .ico in Assets and set IconSource here.
+            Icon = _trayIcon,
         };
         _tray.TrayMouseDoubleClick += (_, _) => ShowOverlay();
         _tray.ForceCreate();
@@ -42,9 +46,97 @@ public partial class App : Application
         _scheduler.Start();
     }
 
+    private enum TrayGlyph { Mug, Pause, Leaf, Cup, Droplet }
+
+    // In OnStartup, change the call to:
+    //     _trayIcon = CreateTrayIcon(TrayGlyph.Mug);
+
+    /// <summary>Draws a crisp white vector glyph as a 32x32 tray icon (font-independent).</summary>
+    private static Icon CreateTrayIcon(TrayGlyph glyph)
+    {
+        const int size = 32;
+        using var bitmap = new Bitmap(size, size);
+        using (var g = Graphics.FromImage(bitmap))
+        {
+            g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
+            g.Clear(Color.Transparent);
+
+            using var white = new Pen(Color.White, 2.4f)
+            {
+                StartCap = System.Drawing.Drawing2D.LineCap.Round,
+                EndCap = System.Drawing.Drawing2D.LineCap.Round,
+                LineJoin = System.Drawing.Drawing2D.LineJoin.Round,
+            };
+            var fill = Brushes.White;
+
+            switch (glyph)
+            {
+                case TrayGlyph.Mug:
+                    // Beer/coffee mug: body + handle + foam.
+                    g.FillRectangle(fill, 8, 12, 12, 14);            // body
+                    g.DrawRectangle(white, 8, 12, 12, 14);
+                    g.DrawArc(white, 18, 13, 8, 9, -90, 180);        // handle
+                    g.FillEllipse(fill, 8, 8, 5, 5);                 // foam
+                    g.FillEllipse(fill, 11, 6, 6, 6);
+                    g.FillEllipse(fill, 15, 8, 5, 5);
+                    break;
+
+                case TrayGlyph.Pause:
+                    // Two rounded bars — "take a break".
+                    g.FillRectangle(fill, 10, 8, 4, 16);
+                    g.FillRectangle(fill, 18, 8, 4, 16);
+                    break;
+
+                case TrayGlyph.Leaf:
+                    // Leaf — calm/rest.
+                    using (var path = new System.Drawing.Drawing2D.GraphicsPath())
+                    {
+                        path.AddBezier(8, 24, 8, 10, 22, 8, 24, 8);
+                        path.AddBezier(24, 8, 24, 22, 10, 24, 8, 24);
+                        g.FillPath(fill, path);
+                    }
+                    g.DrawLine(new Pen(Color.FromArgb(120, 0, 0, 0), 1.2f), 11, 21, 21, 11); // vein notch
+                    break;
+
+                case TrayGlyph.Cup:
+                    // Tea cup with saucer + steam.
+                    g.FillRectangle(fill, 9, 14, 12, 8);             // cup
+                    g.DrawArc(white, 19, 14, 7, 7, -90, 180);        // handle
+                    g.FillRectangle(fill, 7, 23, 16, 2);             // saucer
+                    g.DrawLine(white, 12, 10, 12, 7);                // steam
+                    g.DrawLine(white, 16, 10, 16, 7);
+                    break;
+
+                case TrayGlyph.Droplet:
+                    // Water drop — hydrate.
+                    using (var path = new System.Drawing.Drawing2D.GraphicsPath())
+                    {
+                        path.AddBezier(16, 6, 24, 16, 24, 20, 16, 26);
+                        path.AddBezier(16, 26, 8, 20, 8, 16, 16, 6);
+                        g.FillPath(fill, path);
+                    }
+                    break;
+            }
+        }
+
+        var hIcon = bitmap.GetHicon();
+        try
+        {
+            using var temp = Icon.FromHandle(hIcon);
+            return (Icon)temp.Clone();
+        }
+        finally
+        {
+            DestroyIcon(hIcon);
+        }
+    }
+
+    [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
+    private static extern bool DestroyIcon(IntPtr handle);
+
     private void ShowOverlay()
     {
-        if (_activeOverlay is not null) return; // don't stack overlays
+        if (_activeOverlay is not null) return;
 
         var overlay = new OverlayWindow(_store.Current);
         _activeOverlay = overlay;
@@ -70,7 +162,7 @@ public partial class App : Application
         if (window.Saved)
         {
             _store.Save();
-            _scheduler?.ScheduleNext(); // apply the new interval immediately
+            _scheduler?.ScheduleNext();
         }
     }
 
@@ -80,6 +172,7 @@ public partial class App : Application
     {
         _scheduler?.Stop();
         _tray?.Dispose();
+        _trayIcon?.Dispose();
         _mutex?.Dispose();
     }
 }

--- a/SourceBase.Desktop/App.xaml.cs
+++ b/SourceBase.Desktop/App.xaml.cs
@@ -147,7 +147,7 @@ public partial class App : Application
 
         overlay.Snoozed += (_, _) => { _scheduler?.Snooze(); _habitLogService?.LogSnoozed(); };
         overlay.Dismissed += (_, _) => _habitLogService?.LogDismissed();
-        overlay.HabitPicked += (_, habit) => _habitLogService?.LogHabitStarted(habit.Id, habit.Name);
+        overlay.HabitsStarted += (_, habits) => _habitLogService?.LogHabitsStarted(habits);
         overlay.Closed += (_, _) => _activeOverlay = null;
 
         overlay.Show();

--- a/SourceBase.Desktop/App.xaml.cs
+++ b/SourceBase.Desktop/App.xaml.cs
@@ -1,0 +1,83 @@
+using System.Windows;
+using System.Windows.Controls;
+using H.NotifyIcon;
+using SourceBase.Desktop.Overlay;
+using SourceBase.Desktop.Scheduling;
+using SourceBase.Desktop.Settings;
+
+namespace SourceBase.Desktop;
+
+public partial class App : Application
+{
+    private const string MutexName = "SourceBase.Desktop.SingleInstance";
+    private Mutex? _mutex;
+
+    private readonly SettingsStore _store = new();
+    private TaskbarIcon? _tray;
+    private RestScheduler? _scheduler;
+    private OverlayWindow? _activeOverlay;
+
+    private void OnStartup(object sender, StartupEventArgs e)
+    {
+        _mutex = new Mutex(true, MutexName, out var isNew);
+        if (!isNew)
+        {
+            Shutdown();
+            return;
+        }
+
+        _store.Load();
+
+        _tray = new TaskbarIcon
+        {
+            ToolTipText = "SourceBase — rest reminders",
+            ContextMenu = (ContextMenu)Resources["TrayMenu"],
+            // Icon: ship an .ico in Assets and set IconSource here.
+        };
+        _tray.TrayMouseDoubleClick += (_, _) => ShowOverlay();
+        _tray.ForceCreate();
+
+        _scheduler = new RestScheduler(() => _store.Current);
+        _scheduler.DueForRest += (_, _) => ShowOverlay();
+        _scheduler.Start();
+    }
+
+    private void ShowOverlay()
+    {
+        if (_activeOverlay is not null) return; // don't stack overlays
+
+        var overlay = new OverlayWindow(_store.Current);
+        _activeOverlay = overlay;
+
+        overlay.Snoozed += (_, _) => _scheduler?.Snooze();
+        overlay.HabitPicked += (_, habit) =>
+        {
+            // Phase 1: local only. Phase 2: POST to LogHabitEntry on the SourceBase API.
+        };
+        overlay.Closed += (_, _) => _activeOverlay = null;
+
+        overlay.Show();
+        overlay.Activate();
+    }
+
+    private void OnBreakNow(object sender, RoutedEventArgs e) => ShowOverlay();
+
+    private void OnOpenSettings(object sender, RoutedEventArgs e)
+    {
+        // Phase 1 stub. SettingsWindow comes next — interval/rest/habit editor.
+        MessageBox.Show(
+            $"Interval: every {_store.Current.IntervalMinutes} min\n" +
+            $"Rest: {_store.Current.RestMinutes} min\n" +
+            $"Habits: {_store.Current.Habits.Count}",
+            "SourceBase — Settings (preview)");
+    }
+
+    private void OnExitClicked(object sender, RoutedEventArgs e) => Shutdown();
+
+    private void OnExit(object sender, ExitEventArgs e)
+    {
+        _scheduler?.Stop();
+        _tray?.Dispose();
+        _mutex?.Dispose();
+    }
+}

--- a/SourceBase.Desktop/App.xaml.cs
+++ b/SourceBase.Desktop/App.xaml.cs
@@ -64,12 +64,14 @@ public partial class App : Application
 
     private void OnOpenSettings(object sender, RoutedEventArgs e)
     {
-        // Phase 1 stub. SettingsWindow comes next — interval/rest/habit editor.
-        MessageBox.Show(
-            $"Interval: every {_store.Current.IntervalMinutes} min\n" +
-            $"Rest: {_store.Current.RestMinutes} min\n" +
-            $"Habits: {_store.Current.Habits.Count}",
-            "SourceBase — Settings (preview)");
+        var window = new SettingsWindow(_store.Current);
+        window.ShowDialog();
+
+        if (window.Saved)
+        {
+            _store.Save();
+            _scheduler?.ScheduleNext(); // apply the new interval immediately
+        }
     }
 
     private void OnExitClicked(object sender, RoutedEventArgs e) => Shutdown();

--- a/SourceBase.Desktop/App.xaml.cs
+++ b/SourceBase.Desktop/App.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using H.NotifyIcon;
 using SourceBase.Desktop.Overlay;
 using SourceBase.Desktop.Scheduling;
+using SourceBase.Desktop.Services;
 using SourceBase.Desktop.Settings;
 using System.Drawing;
 using System.Windows;
@@ -16,6 +17,7 @@ public partial class App : Application
     private readonly SettingsStore _store = new();
     private TaskbarIcon? _tray;
     private RestScheduler? _scheduler;
+    private HabitLogService? _habitLogService;
     private OverlayWindow? _activeOverlay;
     private Icon? _trayIcon;
 
@@ -29,6 +31,7 @@ public partial class App : Application
         }
 
         _store.Load();
+        _habitLogService = new HabitLogService(() => _store.Current);
 
         _trayIcon = CreateTrayIcon(TrayGlyph.Mug);
 
@@ -43,6 +46,7 @@ public partial class App : Application
 
         _scheduler = new RestScheduler(() => _store.Current);
         _scheduler.DueForRest += (_, _) => ShowOverlay();
+        _scheduler.VideoSuppressed += (_, _) => _habitLogService?.LogSuppressedVideo();
         _scheduler.Start();
     }
 
@@ -141,11 +145,9 @@ public partial class App : Application
         var overlay = new OverlayWindow(_store.Current);
         _activeOverlay = overlay;
 
-        overlay.Snoozed += (_, _) => _scheduler?.Snooze();
-        overlay.HabitPicked += (_, habit) =>
-        {
-            // Phase 1: local only. Phase 2: POST to LogHabitEntry on the SourceBase API.
-        };
+        overlay.Snoozed += (_, _) => { _scheduler?.Snooze(); _habitLogService?.LogSnoozed(); };
+        overlay.Dismissed += (_, _) => _habitLogService?.LogDismissed();
+        overlay.HabitPicked += (_, habit) => _habitLogService?.LogHabitStarted(habit.Id, habit.Name);
         overlay.Closed += (_, _) => _activeOverlay = null;
 
         overlay.Show();

--- a/SourceBase.Desktop/App.xaml.cs
+++ b/SourceBase.Desktop/App.xaml.cs
@@ -31,7 +31,7 @@ public partial class App : Application
         }
 
         _store.Load();
-        _habitLogService = new HabitLogService(() => _store.Current);
+        _habitLogService = new HabitLogService(() => _store.Current, _store.Save);
 
         _trayIcon = CreateTrayIcon(TrayGlyph.Mug);
 

--- a/SourceBase.Desktop/Models/AppSettings.cs
+++ b/SourceBase.Desktop/Models/AppSettings.cs
@@ -16,10 +16,17 @@ public sealed class AppSettings
 
     /// <summary>Only fire between these hours (24h). Null = always.</summary>
     public int? WorkingHourStart { get; set; } = 9;
-    public int? WorkingHourEnd { get; set; } = 22;
+    public int? WorkingHourEnd { get; set; } = 17;
 
     /// <summary>Launch the app automatically at Windows login.</summary>
     public bool StartAtLogin { get; set; } = false;
+
+    /// <summary>Days the reminder is active. Defaults to weekdays Mon–Fri.</summary>
+    public List<DayOfWeek> ActiveDays { get; set; } =
+    [
+        DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday,
+        DayOfWeek.Thursday, DayOfWeek.Friday,
+    ];
 
     /// <summary>The habits available to pick during a rest.</summary>
     public List<Habit> Habits { get; set; } = DefaultHabits();

--- a/SourceBase.Desktop/Models/AppSettings.cs
+++ b/SourceBase.Desktop/Models/AppSettings.cs
@@ -27,6 +27,9 @@ public sealed class AppSettings
     /// <summary>Bearer token for the SourceBase API. Obtain by logging in via the web app.</summary>
     public string? ApiToken { get; set; }
 
+    /// <summary>Refresh token used to obtain a new access token when ApiToken expires.</summary>
+    public string? ApiRefreshToken { get; set; }
+
     /// <summary>When true, suppress the overlay while a fullscreen / video app is active.</summary>
     public bool PauseDuringVideo { get; set; } = true;
 

--- a/SourceBase.Desktop/Models/AppSettings.cs
+++ b/SourceBase.Desktop/Models/AppSettings.cs
@@ -1,0 +1,36 @@
+namespace SourceBase.Desktop.Models;
+
+/// <summary>
+/// User-configurable settings, persisted to %AppData%\SourceBase.Desktop\settings.json.
+/// </summary>
+public sealed class AppSettings
+{
+    /// <summary>Minutes between rest overlays. Default 30; configurable to 60, etc.</summary>
+    public int IntervalMinutes { get; set; } = 30;
+
+    /// <summary>Length of the suggested rest, shown to the user. Default 5 minutes.</summary>
+    public int RestMinutes { get; set; } = 5;
+
+    /// <summary>Snooze duration when the user defers a break.</summary>
+    public int SnoozeMinutes { get; set; } = 5;
+
+    /// <summary>Only fire between these hours (24h). Null = always.</summary>
+    public int? WorkingHourStart { get; set; } = 9;
+    public int? WorkingHourEnd { get; set; } = 22;
+
+    /// <summary>Launch the app automatically at Windows login.</summary>
+    public bool StartAtLogin { get; set; } = false;
+
+    /// <summary>The habits available to pick during a rest.</summary>
+    public List<Habit> Habits { get; set; } = DefaultHabits();
+
+    public static List<Habit> DefaultHabits() =>
+    [
+        new() { Id = "drink-water", Name = "Drink Water",  Emoji = "💧", Accent = "#3B82F6" },
+        new() { Id = "push-up",     Name = "Push Up",      Emoji = "💪", Accent = "#EF4444" },
+        new() { Id = "stretching",  Name = "Stretching",   Emoji = "🧘", Accent = "#10B981" },
+        new() { Id = "eye-rest",    Name = "Rest Eyes",    Emoji = "👀", Accent = "#8B5CF6" },
+        new() { Id = "walk",        Name = "Short Walk",   Emoji = "🚶", Accent = "#F59E0B" },
+        new() { Id = "deep-breath", Name = "Deep Breaths", Emoji = "🌬️", Accent = "#06B6D4" },
+    ];
+}

--- a/SourceBase.Desktop/Models/AppSettings.cs
+++ b/SourceBase.Desktop/Models/AppSettings.cs
@@ -21,6 +21,12 @@ public sealed class AppSettings
     /// <summary>Launch the app automatically at Windows login.</summary>
     public bool StartAtLogin { get; set; } = false;
 
+    /// <summary>Base URL of the SourceBase API (e.g. https://api.example.com). Leave null to disable logging.</summary>
+    public string? ApiBaseUrl { get; set; }
+
+    /// <summary>Bearer token for the SourceBase API. Obtain by logging in via the web app.</summary>
+    public string? ApiToken { get; set; }
+
     /// <summary>When true, suppress the overlay while a fullscreen / video app is active.</summary>
     public bool PauseDuringVideo { get; set; } = true;
 

--- a/SourceBase.Desktop/Models/AppSettings.cs
+++ b/SourceBase.Desktop/Models/AppSettings.cs
@@ -21,6 +21,21 @@ public sealed class AppSettings
     /// <summary>Launch the app automatically at Windows login.</summary>
     public bool StartAtLogin { get; set; } = false;
 
+    /// <summary>When true, suppress the overlay while a fullscreen / video app is active.</summary>
+    public bool PauseDuringVideo { get; set; } = true;
+
+    /// <summary>Process names (no .exe) that should suppress the overlay when focused.</summary>
+    public List<string> BlockedProcesses { get; set; } =
+    [
+        "stremio",
+        "vlc",
+        "mpc-hc",
+        "mpc-be",
+        "wmplayer",
+        "netflix",
+        "spotify",
+    ];
+
     /// <summary>Days the reminder is active. Defaults to weekdays Mon–Fri.</summary>
     public List<DayOfWeek> ActiveDays { get; set; } =
     [

--- a/SourceBase.Desktop/Models/Habit.cs
+++ b/SourceBase.Desktop/Models/Habit.cs
@@ -7,7 +7,6 @@ namespace SourceBase.Desktop.Models;
 public sealed class Habit
 {
     public required string Id { get; init; }
-
     public required string Name { get; set; }
 
     /// <summary>Emoji shown on the card, e.g. "💧". Optional if ImagePath is set.</summary>

--- a/SourceBase.Desktop/Models/Habit.cs
+++ b/SourceBase.Desktop/Models/Habit.cs
@@ -1,0 +1,24 @@
+namespace SourceBase.Desktop.Models;
+
+/// <summary>
+/// A single habit shown as a card on the rest overlay. Phase 1 is local-only,
+/// so this is a plain serializable model — not the API entity.
+/// </summary>
+public sealed class Habit
+{
+    public required string Id { get; init; }
+
+    public required string Name { get; set; }
+
+    /// <summary>Emoji shown on the card, e.g. "💧". Optional if ImagePath is set.</summary>
+    public string? Emoji { get; set; }
+
+    /// <summary>Optional path to an image file; takes priority over Emoji when present.</summary>
+    public string? ImagePath { get; set; }
+
+    /// <summary>Whether this habit appears in the overlay.</summary>
+    public bool IsEnabled { get; set; } = true;
+
+    /// <summary>Accent color for the card (hex, e.g. "#3B82F6"). Optional.</summary>
+    public string? Accent { get; set; }
+}

--- a/SourceBase.Desktop/Overlay/OverlayWindow.xaml
+++ b/SourceBase.Desktop/Overlay/OverlayWindow.xaml
@@ -29,6 +29,34 @@
                             <Trigger Property="IsMouseOver" Value="True">
                                 <Setter TargetName="b" Property="Background" Value="#E5E7EB"/>
                             </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter Property="Opacity" Value="0.45"/>
+                                <Setter Property="Cursor" Value="Arrow"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="PrimaryButton" TargetType="Button" BasedOn="{StaticResource ActionButton}">
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Background" Value="#3B82F6"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="b" Background="{TemplateBinding Background}"
+                                CornerRadius="10" Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="b" Property="Background" Value="#2563EB"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter Property="Opacity" Value="0.45"/>
+                                <Setter Property="Cursor" Value="Arrow"/>
+                            </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
                 </Setter.Value>
@@ -37,8 +65,8 @@
     </Window.Resources>
 
     <Grid>
-        <!-- Centered white modal -->
-        <Border Width="720" MaxHeight="560"
+        <!-- Centered white modal - sizes to its content so nothing gets clipped -->
+        <Border Width="720"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 Background="White" CornerRadius="20" Padding="44,40">
             <Border.Effect>
@@ -46,14 +74,14 @@
             </Border.Effect>
 
             <Border.RenderTransform>
-                <ScaleTransform x:Name="ModalScale" CenterX="360" CenterY="280" ScaleX="0.96" ScaleY="0.96"/>
+                <ScaleTransform x:Name="ModalScale" CenterX="360" CenterY="260" ScaleX="0.96" ScaleY="0.96"/>
             </Border.RenderTransform>
 
             <StackPanel>
                 <TextBlock Text="Time to rest" FontSize="30" FontWeight="Bold"
                            Foreground="#111827" HorizontalAlignment="Center"/>
                 <TextBlock x:Name="SubtitleText"
-                           Text="Step away for 5 minutes. Pick one to do now."
+                           Text="Step away for 5 minutes. Pick what you'll do."
                            FontSize="15" Foreground="#6B7280"
                            HorizontalAlignment="Center" Margin="0,8,0,4"/>
                 <TextBlock x:Name="CountdownText" Text="" FontSize="13" Foreground="#9CA3AF"
@@ -68,7 +96,10 @@
                     </ItemsControl.ItemsPanel>
                 </ItemsControl>
 
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,28,0,0">
+                <StackPanel x:Name="ActionRow" Orientation="Horizontal"
+                            HorizontalAlignment="Center" Margin="0,28,0,0">
+                    <Button x:Name="StartButton" Content="Start rest"
+                            Style="{StaticResource PrimaryButton}" Margin="0,0,12,0" IsEnabled="False"/>
                     <Button x:Name="SnoozeButton" Content="Snooze 5 min"
                             Style="{StaticResource ActionButton}" Margin="0,0,12,0"/>
                     <Button x:Name="DismissButton" Content="Dismiss"

--- a/SourceBase.Desktop/Overlay/OverlayWindow.xaml
+++ b/SourceBase.Desktop/Overlay/OverlayWindow.xaml
@@ -1,0 +1,80 @@
+<Window x:Class="SourceBase.Desktop.Overlay.OverlayWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        WindowStyle="None"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        Topmost="True"
+        AllowsTransparency="True"
+        Background="#99000000"
+        WindowStartupLocation="Manual">
+
+    <Window.Resources>
+        <Style x:Key="ActionButton" TargetType="Button">
+            <Setter Property="Foreground" Value="#374151"/>
+            <Setter Property="Background" Value="#F3F4F6"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="22,12"/>
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="b" Background="{TemplateBinding Background}"
+                                CornerRadius="10" Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="b" Property="Background" Value="#E5E7EB"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
+
+    <Grid>
+        <!-- Centered white modal -->
+        <Border Width="720" MaxHeight="560"
+                HorizontalAlignment="Center" VerticalAlignment="Center"
+                Background="White" CornerRadius="20" Padding="44,40">
+            <Border.Effect>
+                <DropShadowEffect BlurRadius="40" ShadowDepth="0" Opacity="0.35" Color="#000000"/>
+            </Border.Effect>
+
+            <Border.RenderTransform>
+                <ScaleTransform x:Name="ModalScale" CenterX="360" CenterY="280" ScaleX="0.96" ScaleY="0.96"/>
+            </Border.RenderTransform>
+
+            <StackPanel>
+                <TextBlock Text="Time to rest" FontSize="30" FontWeight="Bold"
+                           Foreground="#111827" HorizontalAlignment="Center"/>
+                <TextBlock x:Name="SubtitleText"
+                           Text="Step away for 5 minutes. Pick one to do now."
+                           FontSize="15" Foreground="#6B7280"
+                           HorizontalAlignment="Center" Margin="0,8,0,4"/>
+                <TextBlock x:Name="CountdownText" Text="" FontSize="13" Foreground="#9CA3AF"
+                           HorizontalAlignment="Center" Margin="0,0,0,24"/>
+
+                <!-- Habit cards injected at runtime -->
+                <ItemsControl x:Name="HabitItems">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <WrapPanel HorizontalAlignment="Center"/>
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                </ItemsControl>
+
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,28,0,0">
+                    <Button x:Name="SnoozeButton" Content="Snooze 5 min"
+                            Style="{StaticResource ActionButton}" Margin="0,0,12,0"/>
+                    <Button x:Name="DismissButton" Content="Dismiss"
+                            Style="{StaticResource ActionButton}"/>
+                </StackPanel>
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/SourceBase.Desktop/Overlay/OverlayWindow.xaml.cs
+++ b/SourceBase.Desktop/Overlay/OverlayWindow.xaml.cs
@@ -11,12 +11,17 @@ namespace SourceBase.Desktop.Overlay;
 
 public partial class OverlayWindow : Window
 {
+    private static readonly FontFamily EmojiFont = new("Segoe UI Emoji");
+
     private readonly AppSettings _settings;
     private readonly DispatcherTimer _restTimer = new() { Interval = TimeSpan.FromSeconds(1) };
+    private readonly HashSet<Habit> _selected = [];
     private TimeSpan _remaining;
     private bool _restStarted;
 
     public event EventHandler? Snoozed;
+
+    /// <summary>Fires once per picked habit when the rest starts.</summary>
     public event EventHandler<Habit>? HabitPicked;
 
     public OverlayWindow(AppSettings settings)
@@ -24,12 +29,13 @@ public partial class OverlayWindow : Window
         InitializeComponent();
         _settings = settings;
 
-        SubtitleText.Text = $"Step away for {settings.RestMinutes} minutes. Pick one to do now.";
+        SubtitleText.Text = $"Step away for {settings.RestMinutes} minutes. Pick what you'll do.";
         SnoozeButton.Content = $"Snooze {settings.SnoozeMinutes} min";
 
         CoverPrimaryScreen();
         BuildCards();
 
+        StartButton.Click += (_, _) => StartRest();
         SnoozeButton.Click += (_, _) => { Snoozed?.Invoke(this, EventArgs.Empty); Close(); };
         DismissButton.Click += (_, _) => Close();
         KeyDown += (_, e) => { if (e.Key == System.Windows.Input.Key.Escape) Close(); };
@@ -40,8 +46,6 @@ public partial class OverlayWindow : Window
 
     private void CoverPrimaryScreen()
     {
-        // Cover the primary working area. Multi-monitor: spawn one window per screen
-        // from the caller using SystemParameters / per-screen bounds.
         Left = SystemParameters.VirtualScreenLeft;
         Top = SystemParameters.VirtualScreenTop;
         Width = SystemParameters.PrimaryScreenWidth;
@@ -93,6 +97,32 @@ public partial class OverlayWindow : Window
         stack.Children.Add(visual);
         stack.Children.Add(label);
 
+        // Checkmark badge (top-right), hidden until selected.
+        var check = new Border
+        {
+            Width = 24,
+            Height = 24,
+            CornerRadius = new CornerRadius(12),
+            Background = new SolidColorBrush(accent),
+            HorizontalAlignment = HorizontalAlignment.Right,
+            VerticalAlignment = VerticalAlignment.Top,
+            Margin = new Thickness(0, 8, 8, 0),
+            Visibility = Visibility.Collapsed,
+            Child = new TextBlock
+            {
+                Text = "\u2713",
+                Foreground = Brushes.White,
+                FontSize = 13,
+                FontWeight = FontWeights.Bold,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+            },
+        };
+
+        var content = new Grid();
+        content.Children.Add(stack);
+        content.Children.Add(check);
+
         var card = new Border
         {
             Width = 140,
@@ -103,29 +133,51 @@ public partial class OverlayWindow : Window
             BorderBrush = new SolidColorBrush(Color.FromRgb(0xEC, 0xEE, 0xF1)),
             BorderThickness = new Thickness(1),
             Cursor = System.Windows.Input.Cursors.Hand,
-            Child = stack,
+            Child = content,
             Tag = habit,
         };
 
-        // Hover: tint border + lift with the accent color.
+        card.MouseLeftButtonUp += (_, _) => ToggleCard(card, check, habit, accent);
         card.MouseEnter += (_, _) =>
         {
-            card.BorderBrush = new SolidColorBrush(accent);
-            card.Background = new SolidColorBrush(Color.FromArgb(0x14, accent.R, accent.G, accent.B));
+            if (!_selected.Contains(habit))
+                card.BorderBrush = new SolidColorBrush(accent);
         };
         card.MouseLeave += (_, _) =>
         {
-            card.BorderBrush = new SolidColorBrush(Color.FromRgb(0xEC, 0xEE, 0xF1));
-            card.Background = new SolidColorBrush(Color.FromRgb(0xF9, 0xFA, 0xFB));
+            if (!_selected.Contains(habit))
+                card.BorderBrush = new SolidColorBrush(Color.FromRgb(0xEC, 0xEE, 0xF1));
         };
-        card.MouseLeftButtonUp += (_, _) => OnHabitPicked(habit);
 
         return card;
     }
 
+    private void ToggleCard(Border card, Border check, Habit habit, Color accent)
+    {
+        if (_restStarted) return;
+
+        if (_selected.Add(habit))
+        {
+            card.BorderBrush = new SolidColorBrush(accent);
+            card.BorderThickness = new Thickness(2);
+            card.Background = new SolidColorBrush(Color.FromArgb(0x14, accent.R, accent.G, accent.B));
+            check.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            _selected.Remove(habit);
+            card.BorderBrush = new SolidColorBrush(Color.FromRgb(0xEC, 0xEE, 0xF1));
+            card.BorderThickness = new Thickness(1);
+            card.Background = new SolidColorBrush(Color.FromRgb(0xF9, 0xFA, 0xFB));
+            check.Visibility = Visibility.Collapsed;
+        }
+
+        StartButton.IsEnabled = _selected.Count > 0;
+        StartButton.Content = _selected.Count > 1 ? $"Start rest ({_selected.Count})" : "Start rest";
+    }
+
     private UIElement BuildVisual(Habit habit)
     {
-        // Prefer an image if one is configured and exists; otherwise the emoji.
         if (!string.IsNullOrWhiteSpace(habit.ImagePath) && File.Exists(habit.ImagePath))
         {
             return new Image
@@ -139,22 +191,28 @@ public partial class OverlayWindow : Window
 
         return new TextBlock
         {
-            Text = habit.Emoji ?? "✅",
+            Text = habit.Emoji ?? "\u2705",
+            FontFamily = EmojiFont,   // color emoji instead of mono glyph fallback
             FontSize = 44,
             HorizontalAlignment = HorizontalAlignment.Center,
         };
     }
 
-    private void OnHabitPicked(Habit habit)
+    private void StartRest()
     {
-        HabitPicked?.Invoke(this, habit);
+        if (_selected.Count == 0) return;
 
-        // Switch the modal into "resting" mode with a countdown.
+        foreach (var habit in _selected)
+            HabitPicked?.Invoke(this, habit);
+
         _restStarted = true;
         HabitItems.Visibility = Visibility.Collapsed;
+        StartButton.Visibility = Visibility.Collapsed;
         SnoozeButton.Visibility = Visibility.Collapsed;
         DismissButton.Content = "I'm done";
-        SubtitleText.Text = $"{habit.Emoji} {habit.Name} — nice. Take your time.";
+
+        var names = string.Join("  ", _selected.Select(h => $"{h.Emoji} {h.Name}"));
+        SubtitleText.Text = $"{names} - nice. Take your time.";
 
         _remaining = TimeSpan.FromMinutes(_settings.RestMinutes);
         UpdateCountdown();
@@ -174,9 +232,7 @@ public partial class OverlayWindow : Window
     }
 
     private void UpdateCountdown() =>
-        CountdownText.Text = _restStarted
-            ? $"{_remaining:m\\:ss} remaining"
-            : string.Empty;
+        CountdownText.Text = _restStarted ? $"{_remaining:m\\:ss} remaining" : string.Empty;
 
     private static Color? ParseColor(string? hex)
     {

--- a/SourceBase.Desktop/Overlay/OverlayWindow.xaml.cs
+++ b/SourceBase.Desktop/Overlay/OverlayWindow.xaml.cs
@@ -21,6 +21,9 @@ public partial class OverlayWindow : Window
 
     public event EventHandler? Snoozed;
 
+    /// <summary>Fires when the overlay is closed without starting a rest (Dismiss button or Escape).</summary>
+    public event EventHandler? Dismissed;
+
     /// <summary>Fires once per picked habit when the rest starts.</summary>
     public event EventHandler<Habit>? HabitPicked;
 
@@ -37,8 +40,17 @@ public partial class OverlayWindow : Window
 
         StartButton.Click += (_, _) => StartRest();
         SnoozeButton.Click += (_, _) => { Snoozed?.Invoke(this, EventArgs.Empty); Close(); };
-        DismissButton.Click += (_, _) => Close();
-        KeyDown += (_, e) => { if (e.Key == System.Windows.Input.Key.Escape) Close(); };
+        DismissButton.Click += (_, _) =>
+        {
+            if (!_restStarted) Dismissed?.Invoke(this, EventArgs.Empty);
+            Close();
+        };
+        KeyDown += (_, e) =>
+        {
+            if (e.Key != System.Windows.Input.Key.Escape) return;
+            if (!_restStarted) Dismissed?.Invoke(this, EventArgs.Empty);
+            Close();
+        };
 
         _restTimer.Tick += OnRestTick;
         Loaded += (_, _) => FadeIn();

--- a/SourceBase.Desktop/Overlay/OverlayWindow.xaml.cs
+++ b/SourceBase.Desktop/Overlay/OverlayWindow.xaml.cs
@@ -24,8 +24,8 @@ public partial class OverlayWindow : Window
     /// <summary>Fires when the overlay is closed without starting a rest (Dismiss button or Escape).</summary>
     public event EventHandler? Dismissed;
 
-    /// <summary>Fires once per picked habit when the rest starts.</summary>
-    public event EventHandler<Habit>? HabitPicked;
+    /// <summary>Fires with all selected habits at once when the rest starts.</summary>
+    public event EventHandler<IReadOnlyList<Habit>>? HabitsStarted;
 
     public OverlayWindow(AppSettings settings)
     {
@@ -214,8 +214,7 @@ public partial class OverlayWindow : Window
     {
         if (_selected.Count == 0) return;
 
-        foreach (var habit in _selected)
-            HabitPicked?.Invoke(this, habit);
+        HabitsStarted?.Invoke(this, [.. _selected]);
 
         _restStarted = true;
         HabitItems.Visibility = Visibility.Collapsed;

--- a/SourceBase.Desktop/Overlay/OverlayWindow.xaml.cs
+++ b/SourceBase.Desktop/Overlay/OverlayWindow.xaml.cs
@@ -1,0 +1,187 @@
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Media.Imaging;
+using System.Windows.Threading;
+using SourceBase.Desktop.Models;
+
+namespace SourceBase.Desktop.Overlay;
+
+public partial class OverlayWindow : Window
+{
+    private readonly AppSettings _settings;
+    private readonly DispatcherTimer _restTimer = new() { Interval = TimeSpan.FromSeconds(1) };
+    private TimeSpan _remaining;
+    private bool _restStarted;
+
+    public event EventHandler? Snoozed;
+    public event EventHandler<Habit>? HabitPicked;
+
+    public OverlayWindow(AppSettings settings)
+    {
+        InitializeComponent();
+        _settings = settings;
+
+        SubtitleText.Text = $"Step away for {settings.RestMinutes} minutes. Pick one to do now.";
+        SnoozeButton.Content = $"Snooze {settings.SnoozeMinutes} min";
+
+        CoverPrimaryScreen();
+        BuildCards();
+
+        SnoozeButton.Click += (_, _) => { Snoozed?.Invoke(this, EventArgs.Empty); Close(); };
+        DismissButton.Click += (_, _) => Close();
+        KeyDown += (_, e) => { if (e.Key == System.Windows.Input.Key.Escape) Close(); };
+
+        _restTimer.Tick += OnRestTick;
+        Loaded += (_, _) => FadeIn();
+    }
+
+    private void CoverPrimaryScreen()
+    {
+        // Cover the primary working area. Multi-monitor: spawn one window per screen
+        // from the caller using SystemParameters / per-screen bounds.
+        Left = SystemParameters.VirtualScreenLeft;
+        Top = SystemParameters.VirtualScreenTop;
+        Width = SystemParameters.PrimaryScreenWidth;
+        Height = SystemParameters.PrimaryScreenHeight;
+        WindowState = WindowState.Normal;
+    }
+
+    private void FadeIn()
+    {
+        Opacity = 0;
+        BeginAnimation(OpacityProperty,
+            new DoubleAnimation(0, 1, TimeSpan.FromMilliseconds(220)));
+
+        var ease = new CubicEase { EasingMode = EasingMode.EaseOut };
+        var scale = new DoubleAnimation(0.96, 1, TimeSpan.FromMilliseconds(260)) { EasingFunction = ease };
+        ModalScale.BeginAnimation(ScaleTransform.ScaleXProperty, scale);
+        ModalScale.BeginAnimation(ScaleTransform.ScaleYProperty, scale);
+    }
+
+    private void BuildCards()
+    {
+        foreach (var habit in _settings.Habits.Where(h => h.IsEnabled))
+            HabitItems.Items.Add(BuildCard(habit));
+    }
+
+    private Border BuildCard(Habit habit)
+    {
+        var accent = ParseColor(habit.Accent) ?? Color.FromRgb(0x37, 0x41, 0x51);
+
+        var visual = new ContentControl
+        {
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Content = BuildVisual(habit),
+            Margin = new Thickness(0, 0, 0, 10),
+        };
+
+        var label = new TextBlock
+        {
+            Text = habit.Name,
+            FontSize = 14,
+            FontWeight = FontWeights.SemiBold,
+            Foreground = new SolidColorBrush(Color.FromRgb(0x1F, 0x29, 0x37)),
+            HorizontalAlignment = HorizontalAlignment.Center,
+            TextWrapping = TextWrapping.Wrap,
+            TextAlignment = TextAlignment.Center,
+        };
+
+        var stack = new StackPanel { VerticalAlignment = VerticalAlignment.Center };
+        stack.Children.Add(visual);
+        stack.Children.Add(label);
+
+        var card = new Border
+        {
+            Width = 140,
+            Height = 140,
+            Margin = new Thickness(8),
+            CornerRadius = new CornerRadius(16),
+            Background = new SolidColorBrush(Color.FromRgb(0xF9, 0xFA, 0xFB)),
+            BorderBrush = new SolidColorBrush(Color.FromRgb(0xEC, 0xEE, 0xF1)),
+            BorderThickness = new Thickness(1),
+            Cursor = System.Windows.Input.Cursors.Hand,
+            Child = stack,
+            Tag = habit,
+        };
+
+        // Hover: tint border + lift with the accent color.
+        card.MouseEnter += (_, _) =>
+        {
+            card.BorderBrush = new SolidColorBrush(accent);
+            card.Background = new SolidColorBrush(Color.FromArgb(0x14, accent.R, accent.G, accent.B));
+        };
+        card.MouseLeave += (_, _) =>
+        {
+            card.BorderBrush = new SolidColorBrush(Color.FromRgb(0xEC, 0xEE, 0xF1));
+            card.Background = new SolidColorBrush(Color.FromRgb(0xF9, 0xFA, 0xFB));
+        };
+        card.MouseLeftButtonUp += (_, _) => OnHabitPicked(habit);
+
+        return card;
+    }
+
+    private UIElement BuildVisual(Habit habit)
+    {
+        // Prefer an image if one is configured and exists; otherwise the emoji.
+        if (!string.IsNullOrWhiteSpace(habit.ImagePath) && File.Exists(habit.ImagePath))
+        {
+            return new Image
+            {
+                Width = 56,
+                Height = 56,
+                Source = new BitmapImage(new Uri(habit.ImagePath)),
+                Stretch = Stretch.Uniform,
+            };
+        }
+
+        return new TextBlock
+        {
+            Text = habit.Emoji ?? "✅",
+            FontSize = 44,
+            HorizontalAlignment = HorizontalAlignment.Center,
+        };
+    }
+
+    private void OnHabitPicked(Habit habit)
+    {
+        HabitPicked?.Invoke(this, habit);
+
+        // Switch the modal into "resting" mode with a countdown.
+        _restStarted = true;
+        HabitItems.Visibility = Visibility.Collapsed;
+        SnoozeButton.Visibility = Visibility.Collapsed;
+        DismissButton.Content = "I'm done";
+        SubtitleText.Text = $"{habit.Emoji} {habit.Name} — nice. Take your time.";
+
+        _remaining = TimeSpan.FromMinutes(_settings.RestMinutes);
+        UpdateCountdown();
+        _restTimer.Start();
+    }
+
+    private void OnRestTick(object? sender, EventArgs e)
+    {
+        _remaining = _remaining.Subtract(TimeSpan.FromSeconds(1));
+        if (_remaining <= TimeSpan.Zero)
+        {
+            _restTimer.Stop();
+            Close();
+            return;
+        }
+        UpdateCountdown();
+    }
+
+    private void UpdateCountdown() =>
+        CountdownText.Text = _restStarted
+            ? $"{_remaining:m\\:ss} remaining"
+            : string.Empty;
+
+    private static Color? ParseColor(string? hex)
+    {
+        if (string.IsNullOrWhiteSpace(hex)) return null;
+        try { return (Color)ColorConverter.ConvertFromString(hex); }
+        catch { return null; }
+    }
+}

--- a/SourceBase.Desktop/README.md
+++ b/SourceBase.Desktop/README.md
@@ -1,0 +1,61 @@
+# SourceBase.Desktop
+
+A local Windows tray app that nudges you to rest. On a configurable interval
+(default **every 30 minutes**) it shows a dimmed fullscreen overlay with a white
+centered modal telling you to step away for ~5 minutes and pick a habit to do —
+shown as emoji/image cards.
+
+This is **Phase 1: local only, no API.** Phase 2 syncs with the SourceBase habit
+tracker submodule (`api.quoctran.qzz.io`).
+
+## Why a tray app, not a Windows Service
+
+Windows Services run in Session 0 and cannot draw on the interactive desktop, so
+they can't show an overlay. The correct pattern (and what BreakTimer does) is a
+background tray app that auto-starts at login. That's this project.
+
+## Run
+
+```bash
+dotnet run --project SourceBase.Desktop
+```
+
+The app starts in the tray. Double-click the tray icon (or "Take a break now")
+to preview the overlay immediately without waiting for the interval.
+
+## Build a portable exe
+
+```bash
+dotnet publish SourceBase.Desktop -c Release -p:PublishSingleFile=true
+```
+
+## Settings
+
+Stored at `%AppData%\SourceBase.Desktop\settings.json`. Defaults:
+
+- Interval: 30 min (set to 60 for hourly, etc.)
+- Rest length: 5 min
+- Working hours: 09:00–22:00
+- Default habits: Drink Water 💧, Push Up 💪, Stretching 🧘, Rest Eyes 👀,
+  Short Walk 🚶, Deep Breaths 🌬️
+
+Each habit can use an emoji or an `imagePath` (image takes priority).
+
+## Project layout
+
+```
+Models/        Habit, AppSettings (+ default seed)
+Settings/      SettingsStore — JSON load/save to %AppData%
+Scheduling/    RestScheduler — interval timer + working-hours gate
+Overlay/       OverlayWindow — dimmed backdrop, white modal, habit cards, rest countdown
+App.xaml(.cs)  Tray icon, single-instance mutex, wiring
+```
+
+## Phase 2 (later)
+
+- Settings window (interval/rest/working-hours/habit editor) — replaces the stub dialog
+- Multi-monitor overlays (one window per screen)
+- "Start at login" registry toggle
+- Idle detection (skip reminders when away — `GetLastInputInfo`)
+- Write picked habit back to the API via `LogHabitEntry`
+- Pull habit list from the API instead of local defaults

--- a/SourceBase.Desktop/Scheduling/PresentationDetector.cs
+++ b/SourceBase.Desktop/Scheduling/PresentationDetector.cs
@@ -1,0 +1,129 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace SourceBase.Desktop.Scheduling;
+
+/// <summary>
+/// Decides whether a rest overlay should be suppressed because the user is
+/// watching video / presenting / gaming. Combines the Windows notification
+/// state (covers fullscreen video and games) with a process-name check
+/// (covers windowed players like Stremio or a browser playing YouTube).
+/// </summary>
+public static class PresentationDetector
+{
+    public static bool ShouldSuppress(IEnumerable<string> blockedProcesses)
+    {
+        if (IsWindowsBusy()) return true;
+        if (IsFullscreenForeground()) return true;
+        if (IsBlockedProcessForeground(blockedProcesses)) return true;
+        return false;
+    }
+
+    // --- Windows "do not disturb" notification state ---------------------
+
+    private enum QueryUserNotificationState
+    {
+        NotPresent = 1,
+        Busy = 2,            // a full-screen app is running (game/video)
+        RunningD3dFullScreen = 3,
+        PresentationMode = 4, // presentation mode is on
+        AcceptsNotifications = 5,
+        QuietTime = 6,
+        App = 7,
+    }
+
+    [DllImport("shell32.dll")]
+    private static extern int SHQueryUserNotificationState(out QueryUserNotificationState state);
+
+    private static bool IsWindowsBusy()
+    {
+        try
+        {
+            if (SHQueryUserNotificationState(out var state) != 0) return false;
+            return state is QueryUserNotificationState.Busy
+                or QueryUserNotificationState.RunningD3dFullScreen
+                or QueryUserNotificationState.PresentationMode
+                or QueryUserNotificationState.QuietTime;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    // --- Fullscreen foreground window (covers borderless fullscreen) -----
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
+
+    [DllImport("user32.dll")]
+    private static extern bool GetWindowRect(IntPtr hWnd, out Rect rect);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetDesktopWindow();
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetShellWindow();
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Rect { public int Left, Top, Right, Bottom; }
+
+    private static bool IsFullscreenForeground()
+    {
+        try
+        {
+            var fg = GetForegroundWindow();
+            if (fg == IntPtr.Zero) return false;
+            if (fg == GetDesktopWindow() || fg == GetShellWindow()) return false;
+            if (!GetWindowRect(fg, out var r)) return false;
+
+            var w = r.Right - r.Left;
+            var h = r.Bottom - r.Top;
+
+            // Compare against the full virtual screen (handles multi-monitor).
+            var screenW = (int)SystemParametersWidth();
+            var screenH = (int)SystemParametersHeight();
+            return w >= screenW && h >= screenH;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static double SystemParametersWidth() =>
+        System.Windows.SystemParameters.PrimaryScreenWidth;
+
+    private static double SystemParametersHeight() =>
+        System.Windows.SystemParameters.PrimaryScreenHeight;
+
+    // --- Blocked process is the foreground app ---------------------------
+
+    [DllImport("user32.dll")]
+    private static extern int GetWindowThreadProcessId(IntPtr hWnd, out int processId);
+
+    private static bool IsBlockedProcessForeground(IEnumerable<string> blocked)
+    {
+        try
+        {
+            var fg = GetForegroundWindow();
+            if (fg == IntPtr.Zero) return false;
+
+            GetWindowThreadProcessId(fg, out var pid);
+            if (pid == 0) return false;
+
+            using var proc = Process.GetProcessById(pid);
+            var name = proc.ProcessName; // e.g. "stremio", "vlc", "chrome"
+
+            foreach (var b in blocked)
+                if (name.Contains(b, StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/SourceBase.Desktop/Scheduling/RestScheduler.cs
+++ b/SourceBase.Desktop/Scheduling/RestScheduler.cs
@@ -45,11 +45,16 @@ public sealed class RestScheduler
     private void OnTick(object? sender, EventArgs e)
     {
         if (DateTime.Now < _nextDue) return;
-        if (!WithinWorkingHours(_settings())) { ScheduleNext(); return; }
+
+        var s = _settings();
+        if (!IsActiveDay(s) || !WithinWorkingHours(s)) { ScheduleNext(); return; }
 
         ScheduleNext();
         DueForRest?.Invoke(this, EventArgs.Empty);
     }
+
+    private static bool IsActiveDay(AppSettings s) =>
+        s.ActiveDays.Count == 0 || s.ActiveDays.Contains(DateTime.Now.DayOfWeek);
 
     private static bool WithinWorkingHours(AppSettings s)
     {

--- a/SourceBase.Desktop/Scheduling/RestScheduler.cs
+++ b/SourceBase.Desktop/Scheduling/RestScheduler.cs
@@ -36,8 +36,24 @@ public sealed class RestScheduler
     /// <summary>Reset the countdown — call after settings change or after a rest is shown/snoozed.</summary>
     public void ScheduleNext(int? overrideMinutes = null)
     {
-        var minutes = overrideMinutes ?? _settings().IntervalMinutes;
-        _nextDue = DateTime.Now.AddMinutes(Math.Max(1, minutes));
+        if (overrideMinutes is not null)
+        {
+            // Snooze: relative delay from now.
+            _nextDue = DateTime.Now.AddMinutes(Math.Max(1, overrideMinutes.Value));
+            return;
+        }
+        _nextDue = NextAlignedSlot(DateTime.Now, _settings());
+    }
+
+    // Snaps to the next N-minute slot anchored at WorkingHourStart (or midnight if unset).
+    // e.g. start=9:00, interval=30 → slots are 9:00, 9:30, 10:00, 10:30 …
+    private static DateTime NextAlignedSlot(DateTime now, AppSettings s)
+    {
+        var interval = Math.Max(1, s.IntervalMinutes);
+        var anchor = now.Date.AddHours(s.WorkingHourStart ?? 0);
+        if (now < anchor) return anchor;
+        var elapsed = (long)((now - anchor).TotalMinutes / interval);
+        return anchor.AddMinutes((elapsed + 1) * interval);
     }
 
     public void Snooze() => ScheduleNext(_settings().SnoozeMinutes);

--- a/SourceBase.Desktop/Scheduling/RestScheduler.cs
+++ b/SourceBase.Desktop/Scheduling/RestScheduler.cs
@@ -49,6 +49,14 @@ public sealed class RestScheduler
         var s = _settings();
         if (!IsActiveDay(s) || !WithinWorkingHours(s)) { ScheduleNext(); return; }
 
+        if (s.PauseDuringVideo && PresentationDetector.ShouldSuppress(s.BlockedProcesses))
+        {
+            // Don't reset the full interval — retry shortly so the reminder
+            // fires soon after the video ends, not a full interval later.
+            _nextDue = DateTime.Now.AddMinutes(2);
+            return;
+        }
+
         ScheduleNext();
         DueForRest?.Invoke(this, EventArgs.Empty);
     }

--- a/SourceBase.Desktop/Scheduling/RestScheduler.cs
+++ b/SourceBase.Desktop/Scheduling/RestScheduler.cs
@@ -1,0 +1,64 @@
+using System.Windows.Threading;
+using SourceBase.Desktop.Models;
+
+namespace SourceBase.Desktop.Scheduling;
+
+/// <summary>
+/// Drives the rest reminder. Ticks once a minute, and raises <see cref="DueForRest"/>
+/// when the configured interval has elapsed since the last rest, provided the current
+/// time falls inside working hours.
+/// </summary>
+public sealed class RestScheduler
+{
+    private readonly DispatcherTimer _timer;
+    private readonly Func<AppSettings> _settings;
+    private DateTime _nextDue;
+
+    public event EventHandler? DueForRest;
+
+    public DateTime NextDue => _nextDue;
+
+    public RestScheduler(Func<AppSettings> settings)
+    {
+        _settings = settings;
+        _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(20) };
+        _timer.Tick += OnTick;
+    }
+
+    public void Start()
+    {
+        ScheduleNext();
+        _timer.Start();
+    }
+
+    public void Stop() => _timer.Stop();
+
+    /// <summary>Reset the countdown — call after settings change or after a rest is shown/snoozed.</summary>
+    public void ScheduleNext(int? overrideMinutes = null)
+    {
+        var minutes = overrideMinutes ?? _settings().IntervalMinutes;
+        _nextDue = DateTime.Now.AddMinutes(Math.Max(1, minutes));
+    }
+
+    public void Snooze() => ScheduleNext(_settings().SnoozeMinutes);
+
+    private void OnTick(object? sender, EventArgs e)
+    {
+        if (DateTime.Now < _nextDue) return;
+        if (!WithinWorkingHours(_settings())) { ScheduleNext(); return; }
+
+        ScheduleNext();
+        DueForRest?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static bool WithinWorkingHours(AppSettings s)
+    {
+        if (s.WorkingHourStart is null || s.WorkingHourEnd is null) return true;
+        var hour = DateTime.Now.Hour;
+        var start = s.WorkingHourStart.Value;
+        var end = s.WorkingHourEnd.Value;
+        return start <= end
+            ? hour >= start && hour < end
+            : hour >= start || hour < end; // wraps past midnight
+    }
+}

--- a/SourceBase.Desktop/Scheduling/RestScheduler.cs
+++ b/SourceBase.Desktop/Scheduling/RestScheduler.cs
@@ -13,8 +13,12 @@ public sealed class RestScheduler
     private readonly DispatcherTimer _timer;
     private readonly Func<AppSettings> _settings;
     private DateTime _nextDue;
+    private bool _videoSuppressedLogged;
 
     public event EventHandler? DueForRest;
+
+    /// <summary>Fires once per video/game session when a due reminder is suppressed.</summary>
+    public event EventHandler? VideoSuppressed;
 
     public DateTime NextDue => _nextDue;
 
@@ -67,11 +71,17 @@ public sealed class RestScheduler
 
         if (s.PauseDuringVideo && PresentationDetector.ShouldSuppress(s.BlockedProcesses))
         {
+            if (!_videoSuppressedLogged)
+            {
+                _videoSuppressedLogged = true;
+                VideoSuppressed?.Invoke(this, EventArgs.Empty);
+            }
             // Don't reset the full interval — retry shortly so the reminder
             // fires soon after the video ends, not a full interval later.
             _nextDue = DateTime.Now.AddMinutes(2);
             return;
         }
+        _videoSuppressedLogged = false;
 
         ScheduleNext();
         DueForRest?.Invoke(this, EventArgs.Empty);

--- a/SourceBase.Desktop/Services/HabitLogService.cs
+++ b/SourceBase.Desktop/Services/HabitLogService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -9,8 +10,9 @@ namespace SourceBase.Desktop.Services;
 /// <summary>
 /// Fire-and-forget client that batch-POSTs habit log actions to the SourceBase API.
 /// Silently no-ops when ApiBaseUrl/ApiToken are not configured or the API is unreachable.
+/// Automatically refreshes the access token via ApiRefreshToken on 401 and retries once.
 /// </summary>
-public sealed class HabitLogService(Func<AppSettings> settings)
+public sealed class HabitLogService(Func<AppSettings> settings, Action onSave)
 {
     private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(5) };
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
@@ -35,15 +37,51 @@ public sealed class HabitLogService(Func<AppSettings> settings)
         try
         {
             var body = JsonSerializer.Serialize(new { entries }, JsonOpts);
-            using var req = new HttpRequestMessage(HttpMethod.Post, $"{s.ApiBaseUrl.TrimEnd('/')}/api/habit-logs")
-            {
-                Headers = { Authorization = new AuthenticationHeaderValue("Bearer", s.ApiToken) },
-                Content = new StringContent(body, Encoding.UTF8, "application/json"),
-            };
-            await Http.SendAsync(req);
+            var url = $"{s.ApiBaseUrl.TrimEnd('/')}/api/habit-logs";
+
+            var resp = await PostAsync(url, body, s.ApiToken);
+
+            if (resp.StatusCode == HttpStatusCode.Unauthorized && await TryRefreshAsync(s))
+                await PostAsync(url, body, s.ApiToken!);
         }
         catch { }
     }
 
+    private static async Task<HttpResponseMessage> PostAsync(string url, string body, string token)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Headers = { Authorization = new AuthenticationHeaderValue("Bearer", token) },
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+        return await Http.SendAsync(req);
+    }
+
+    private async Task<bool> TryRefreshAsync(AppSettings s)
+    {
+        if (string.IsNullOrWhiteSpace(s.ApiRefreshToken)) return false;
+        try
+        {
+            var payload = JsonSerializer.Serialize(new { token = s.ApiRefreshToken }, JsonOpts);
+            using var req = new HttpRequestMessage(HttpMethod.Post, $"{s.ApiBaseUrl!.TrimEnd('/')}/api/auth/refresh")
+            {
+                Content = new StringContent(payload, Encoding.UTF8, "application/json"),
+            };
+            var resp = await Http.SendAsync(req);
+            if (!resp.IsSuccessStatusCode) return false;
+
+            var tokens = await JsonSerializer.DeserializeAsync<TokenResponse>(
+                await resp.Content.ReadAsStreamAsync(), JsonOpts);
+            if (tokens is null || string.IsNullOrWhiteSpace(tokens.AccessToken)) return false;
+
+            s.ApiToken = tokens.AccessToken;
+            s.ApiRefreshToken = tokens.RefreshToken;
+            onSave();
+            return true;
+        }
+        catch { return false; }
+    }
+
     private record Entry(string? HabitId, string? HabitName, string Action, DateTime OccurredAt);
+    private record TokenResponse(string AccessToken, string RefreshToken);
 }

--- a/SourceBase.Desktop/Services/HabitLogService.cs
+++ b/SourceBase.Desktop/Services/HabitLogService.cs
@@ -7,7 +7,7 @@ using SourceBase.Desktop.Models;
 namespace SourceBase.Desktop.Services;
 
 /// <summary>
-/// Fire-and-forget client that POSTs habit log actions to the SourceBase API.
+/// Fire-and-forget client that batch-POSTs habit log actions to the SourceBase API.
 /// Silently no-ops when ApiBaseUrl/ApiToken are not configured or the API is unreachable.
 /// </summary>
 public sealed class HabitLogService(Func<AppSettings> settings)
@@ -15,21 +15,26 @@ public sealed class HabitLogService(Func<AppSettings> settings)
     private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(5) };
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
-    public void LogHabitStarted(string? habitId, string? habitName) => Send(habitId, habitName, "HabitStarted");
-    public void LogDismissed() => Send(null, null, "Dismissed");
-    public void LogSnoozed() => Send(null, null, "Snoozed");
-    public void LogSuppressedVideo() => Send(null, null, "SuppressedVideo");
+    public void LogHabitsStarted(IEnumerable<Habit> habits)
+    {
+        var now = DateTime.UtcNow;
+        Send(habits.Select(h => new Entry(h.Id, h.Name, "HabitStarted", now)));
+    }
 
-    private void Send(string? habitId, string? habitName, string action) => _ = SendAsync(habitId, habitName, action);
+    public void LogDismissed() => Send([new Entry(null, null, "Dismissed", DateTime.UtcNow)]);
+    public void LogSnoozed() => Send([new Entry(null, null, "Snoozed", DateTime.UtcNow)]);
+    public void LogSuppressedVideo() => Send([new Entry(null, null, "SuppressedVideo", DateTime.UtcNow)]);
 
-    private async Task SendAsync(string? habitId, string? habitName, string action)
+    private void Send(IEnumerable<Entry> entries) => _ = SendAsync(entries);
+
+    private async Task SendAsync(IEnumerable<Entry> entries)
     {
         var s = settings();
         if (string.IsNullOrWhiteSpace(s.ApiBaseUrl) || string.IsNullOrWhiteSpace(s.ApiToken)) return;
 
         try
         {
-            var body = JsonSerializer.Serialize(new { habitId, habitName, action, occurredAt = DateTime.UtcNow }, JsonOpts);
+            var body = JsonSerializer.Serialize(new { entries }, JsonOpts);
             using var req = new HttpRequestMessage(HttpMethod.Post, $"{s.ApiBaseUrl.TrimEnd('/')}/api/habit-logs")
             {
                 Headers = { Authorization = new AuthenticationHeaderValue("Bearer", s.ApiToken) },
@@ -39,4 +44,6 @@ public sealed class HabitLogService(Func<AppSettings> settings)
         }
         catch { }
     }
+
+    private record Entry(string? HabitId, string? HabitName, string Action, DateTime OccurredAt);
 }

--- a/SourceBase.Desktop/Services/HabitLogService.cs
+++ b/SourceBase.Desktop/Services/HabitLogService.cs
@@ -1,0 +1,42 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using SourceBase.Desktop.Models;
+
+namespace SourceBase.Desktop.Services;
+
+/// <summary>
+/// Fire-and-forget client that POSTs habit log actions to the SourceBase API.
+/// Silently no-ops when ApiBaseUrl/ApiToken are not configured or the API is unreachable.
+/// </summary>
+public sealed class HabitLogService(Func<AppSettings> settings)
+{
+    private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(5) };
+    private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    public void LogHabitStarted(string? habitId, string? habitName) => Send(habitId, habitName, "HabitStarted");
+    public void LogDismissed() => Send(null, null, "Dismissed");
+    public void LogSnoozed() => Send(null, null, "Snoozed");
+    public void LogSuppressedVideo() => Send(null, null, "SuppressedVideo");
+
+    private void Send(string? habitId, string? habitName, string action) => _ = SendAsync(habitId, habitName, action);
+
+    private async Task SendAsync(string? habitId, string? habitName, string action)
+    {
+        var s = settings();
+        if (string.IsNullOrWhiteSpace(s.ApiBaseUrl) || string.IsNullOrWhiteSpace(s.ApiToken)) return;
+
+        try
+        {
+            var body = JsonSerializer.Serialize(new { habitId, habitName, action, occurredAt = DateTime.UtcNow }, JsonOpts);
+            using var req = new HttpRequestMessage(HttpMethod.Post, $"{s.ApiBaseUrl.TrimEnd('/')}/api/habit-logs")
+            {
+                Headers = { Authorization = new AuthenticationHeaderValue("Bearer", s.ApiToken) },
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+            await Http.SendAsync(req);
+        }
+        catch { }
+    }
+}

--- a/SourceBase.Desktop/Settings/SettingsStore.cs
+++ b/SourceBase.Desktop/Settings/SettingsStore.cs
@@ -1,0 +1,63 @@
+using System.IO;
+using System.Text.Json;
+using SourceBase.Desktop.Models;
+
+namespace SourceBase.Desktop.Settings;
+
+/// <summary>
+/// Loads and persists <see cref="AppSettings"/> as JSON under
+/// %AppData%\SourceBase.Desktop\settings.json — mirrors BreakTimer's %AppData% storage.
+/// </summary>
+public sealed class SettingsStore
+{
+    private static readonly string Dir = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "SourceBase.Desktop");
+
+    private static readonly string FilePath = Path.Combine(Dir, "settings.json");
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    public AppSettings Current { get; private set; } = new();
+
+    public AppSettings Load()
+    {
+        try
+        {
+            if (File.Exists(FilePath))
+            {
+                var json = File.ReadAllText(FilePath);
+                var loaded = JsonSerializer.Deserialize<AppSettings>(json, JsonOpts);
+                if (loaded is not null)
+                {
+                    // Guard against an empty habit list from a hand-edited file.
+                    if (loaded.Habits.Count == 0)
+                        loaded.Habits = AppSettings.DefaultHabits();
+                    Current = loaded;
+                }
+            }
+            else
+            {
+                Save(); // write defaults on first run
+            }
+        }
+        catch
+        {
+            // Corrupt file → fall back to defaults rather than crashing on startup.
+            Current = new AppSettings();
+        }
+
+        return Current;
+    }
+
+    public void Save()
+    {
+        Directory.CreateDirectory(Dir);
+        var json = JsonSerializer.Serialize(Current, JsonOpts);
+        File.WriteAllText(FilePath, json);
+    }
+}

--- a/SourceBase.Desktop/Settings/SettingsWindow.xaml
+++ b/SourceBase.Desktop/Settings/SettingsWindow.xaml
@@ -188,11 +188,26 @@
             </Grid>
 
             <!-- Actions -->
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button x:Name="CancelButton" Content="Cancel"
-                        Style="{StaticResource Ghost}" Margin="0,0,12,0"/>
-                <Button x:Name="SaveButton" Content="Save" Style="{StaticResource Primary}"/>
-            </StackPanel>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Left: Test Connection -->
+                <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                    <Button x:Name="TestButton" Content="Test Connection" Style="{StaticResource Ghost}"/>
+                    <TextBlock x:Name="TestResultText" Margin="10,0,0,0" VerticalAlignment="Center"
+                               FontSize="13" FontWeight="SemiBold" Visibility="Collapsed"/>
+                </StackPanel>
+
+                <!-- Right: Cancel + Save -->
+                <StackPanel Grid.Column="1" Orientation="Horizontal">
+                    <Button x:Name="CancelButton" Content="Cancel"
+                            Style="{StaticResource Ghost}" Margin="0,0,12,0"/>
+                    <Button x:Name="SaveButton" Content="Save" Style="{StaticResource Primary}"/>
+                </StackPanel>
+            </Grid>
         </StackPanel>
     </Border>
 </Window>

--- a/SourceBase.Desktop/Settings/SettingsWindow.xaml
+++ b/SourceBase.Desktop/Settings/SettingsWindow.xaml
@@ -128,7 +128,18 @@
 
             <!-- Days of week -->
             <TextBlock Text="Repeat on" Style="{StaticResource Label}"/>
-            <StackPanel x:Name="DayRow" Orientation="Horizontal" Margin="0,0,0,32"/>
+            <StackPanel x:Name="DayRow" Orientation="Horizontal" Margin="0,0,0,24"/>
+
+            <!-- Pause during video -->
+            <CheckBox x:Name="PauseDuringVideoBox" Margin="0,0,0,32"
+                      VerticalContentAlignment="Center" Cursor="Hand">
+                <StackPanel>
+                    <TextBlock Text="Pause during video" FontSize="13" FontWeight="SemiBold"
+                               Foreground="#374151"/>
+                    <TextBlock Text="Skip reminders while watching fullscreen video or gaming"
+                               FontSize="12" Foreground="#9CA3AF" Margin="0,2,0,0"/>
+                </StackPanel>
+            </CheckBox>
 
             <!-- Actions -->
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">

--- a/SourceBase.Desktop/Settings/SettingsWindow.xaml
+++ b/SourceBase.Desktop/Settings/SettingsWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="SourceBase.Desktop.Settings.SettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="SourceBase — Schedule"
+        Title="SourceBase — Settings"
         Width="560" SizeToContent="Height"
         WindowStyle="None" ResizeMode="NoResize"
         AllowsTransparency="True" Background="Transparent"
@@ -66,6 +66,16 @@
             </Setter>
         </Style>
 
+        <Style x:Key="TextField" TargetType="TextBox">
+            <Setter Property="Height" Value="36"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="Padding" Value="10,0"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="BorderBrush" Value="#D1D5DB"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Background" Value="#F9FAFB"/>
+        </Style>
+
         <!-- Day-of-week pill toggle -->
         <Style x:Key="DayPill" TargetType="ToggleButton">
             <Setter Property="Width" Value="58"/>
@@ -104,8 +114,8 @@
         </Border.Effect>
 
         <StackPanel>
-            <TextBlock Text="Schedule" FontSize="26" FontWeight="Bold" Foreground="#111827"/>
-            <TextBlock Text="When should rest reminders appear?"
+            <TextBlock Text="Settings" FontSize="26" FontWeight="Bold" Foreground="#111827"/>
+            <TextBlock Text="Schedule and API connection"
                        FontSize="14" Foreground="#6B7280" Margin="0,6,0,28"/>
 
             <!-- Working hours -->
@@ -140,6 +150,42 @@
                                FontSize="12" Foreground="#9CA3AF" Margin="0,2,0,0"/>
                 </StackPanel>
             </CheckBox>
+
+            <!-- API Connection -->
+            <Border Height="1" Background="#E5E7EB" Margin="0,0,0,24"/>
+            <TextBlock Text="API Connection" Style="{StaticResource Label}"/>
+            <TextBlock Text="Sync habit logs with the SourceBase web app."
+                       FontSize="12" Foreground="#9CA3AF" Margin="0,-4,0,16"/>
+
+            <Grid Margin="0,0,0,10">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="110"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="API URL" Grid.Column="0" VerticalAlignment="Center"
+                           FontSize="12" FontWeight="SemiBold" Foreground="#374151"/>
+                <TextBox x:Name="ApiUrlBox" Grid.Column="1" Style="{StaticResource TextField}"/>
+            </Grid>
+
+            <Grid Margin="0,0,0,10">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="110"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="Access Token" Grid.Column="0" VerticalAlignment="Center"
+                           FontSize="12" FontWeight="SemiBold" Foreground="#374151"/>
+                <TextBox x:Name="AccessTokenBox" Grid.Column="1" Style="{StaticResource TextField}"/>
+            </Grid>
+
+            <Grid Margin="0,0,0,32">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="110"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="Refresh Token" Grid.Column="0" VerticalAlignment="Center"
+                           FontSize="12" FontWeight="SemiBold" Foreground="#374151"/>
+                <TextBox x:Name="RefreshTokenBox" Grid.Column="1" Style="{StaticResource TextField}"/>
+            </Grid>
 
             <!-- Actions -->
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">

--- a/SourceBase.Desktop/Settings/SettingsWindow.xaml
+++ b/SourceBase.Desktop/Settings/SettingsWindow.xaml
@@ -1,0 +1,141 @@
+<Window x:Class="SourceBase.Desktop.Settings.SettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="SourceBase — Schedule"
+        Width="560" SizeToContent="Height"
+        WindowStyle="None" ResizeMode="NoResize"
+        AllowsTransparency="True" Background="Transparent"
+        WindowStartupLocation="CenterScreen">
+
+    <Window.Resources>
+        <Style x:Key="Label" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Foreground" Value="#374151"/>
+            <Setter Property="Margin" Value="0,0,0,8"/>
+        </Style>
+
+        <Style x:Key="Field" TargetType="ComboBox">
+            <Setter Property="Height" Value="38"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="Padding" Value="10,0"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+
+        <Style x:Key="Primary" TargetType="Button">
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Background" Value="#3B82F6"/>
+            <Setter Property="Padding" Value="24,11"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="b" Background="{TemplateBinding Background}"
+                                CornerRadius="10" Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="b" Property="Background" Value="#2563EB"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="Ghost" TargetType="Button" BasedOn="{StaticResource Primary}">
+            <Setter Property="Background" Value="#F3F4F6"/>
+            <Setter Property="Foreground" Value="#374151"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="b" Background="{TemplateBinding Background}"
+                                CornerRadius="10" Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="b" Property="Background" Value="#E5E7EB"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <!-- Day-of-week pill toggle -->
+        <Style x:Key="DayPill" TargetType="ToggleButton">
+            <Setter Property="Width" Value="58"/>
+            <Setter Property="Height" Value="40"/>
+            <Setter Property="Margin" Value="0,0,8,0"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Foreground" Value="#6B7280"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ToggleButton">
+                        <Border x:Name="b" Background="#F9FAFB" BorderBrush="#ECEEF1"
+                                BorderThickness="1" CornerRadius="10">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsChecked" Value="True">
+                                <Setter TargetName="b" Property="Background" Value="#3B82F6"/>
+                                <Setter TargetName="b" Property="BorderBrush" Value="#3B82F6"/>
+                                <Setter Property="Foreground" Value="White"/>
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="b" Property="BorderBrush" Value="#3B82F6"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
+
+    <Border Background="White" CornerRadius="20" Padding="40,36" Margin="20">
+        <Border.Effect>
+            <DropShadowEffect BlurRadius="40" ShadowDepth="0" Opacity="0.3" Color="#000000"/>
+        </Border.Effect>
+
+        <StackPanel>
+            <TextBlock Text="Schedule" FontSize="26" FontWeight="Bold" Foreground="#111827"/>
+            <TextBlock Text="When should rest reminders appear?"
+                       FontSize="14" Foreground="#6B7280" Margin="0,6,0,28"/>
+
+            <!-- Working hours -->
+            <TextBlock Text="Active hours" Style="{StaticResource Label}"/>
+            <Grid Margin="0,0,0,24">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <ComboBox x:Name="StartHour" Grid.Column="0" Style="{StaticResource Field}"/>
+                <TextBlock Grid.Column="1" Text="to" VerticalAlignment="Center"
+                           Margin="14,0" Foreground="#9CA3AF" FontSize="14"/>
+                <ComboBox x:Name="EndHour" Grid.Column="2" Style="{StaticResource Field}"/>
+            </Grid>
+
+            <!-- Repeat interval -->
+            <TextBlock Text="Remind me every" Style="{StaticResource Label}"/>
+            <ComboBox x:Name="IntervalBox" Style="{StaticResource Field}" Margin="0,0,0,24"/>
+
+            <!-- Days of week -->
+            <TextBlock Text="Repeat on" Style="{StaticResource Label}"/>
+            <StackPanel x:Name="DayRow" Orientation="Horizontal" Margin="0,0,0,32"/>
+
+            <!-- Actions -->
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button x:Name="CancelButton" Content="Cancel"
+                        Style="{StaticResource Ghost}" Margin="0,0,12,0"/>
+                <Button x:Name="SaveButton" Content="Save" Style="{StaticResource Primary}"/>
+            </StackPanel>
+        </StackPanel>
+    </Border>
+</Window>

--- a/SourceBase.Desktop/Settings/SettingsWindow.xaml.cs
+++ b/SourceBase.Desktop/Settings/SettingsWindow.xaml.cs
@@ -1,0 +1,124 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using SourceBase.Desktop.Models;
+
+namespace SourceBase.Desktop.Settings;
+
+public partial class SettingsWindow : Window
+{
+    private readonly AppSettings _settings;
+
+    // Interval options shown in the dropdown, label → minutes.
+    private static readonly (string Label, int Minutes)[] Intervals =
+    [
+        ("15 minutes", 15),
+        ("30 minutes", 30),
+        ("45 minutes", 45),
+        ("1 hour", 60),
+        ("1.5 hours", 90),
+        ("2 hours", 120),
+    ];
+
+    private static readonly (string Label, DayOfWeek Day)[] Days =
+    [
+        ("Mon", DayOfWeek.Monday),
+        ("Tue", DayOfWeek.Tuesday),
+        ("Wed", DayOfWeek.Wednesday),
+        ("Thu", DayOfWeek.Thursday),
+        ("Fri", DayOfWeek.Friday),
+        ("Sat", DayOfWeek.Saturday),
+        ("Sun", DayOfWeek.Sunday),
+    ];
+
+    /// <summary>True when the user pressed Save (so the caller can persist + reschedule).</summary>
+    public bool Saved { get; private set; }
+
+    public SettingsWindow(AppSettings settings)
+    {
+        InitializeComponent();
+        _settings = settings;
+
+        PopulateHours();
+        PopulateInterval();
+        PopulateDays();
+
+        MouseLeftButtonDown += (_, e) => { if (e.ButtonState == MouseButtonState.Pressed) DragMove(); };
+        CancelButton.Click += (_, _) => Close();
+        SaveButton.Click += OnSave;
+    }
+
+    private void PopulateHours()
+    {
+        for (var h = 0; h < 24; h++)
+        {
+            var label = FormatHour(h);
+            StartHour.Items.Add(new ComboBoxItem { Content = label, Tag = h });
+            EndHour.Items.Add(new ComboBoxItem { Content = label, Tag = h });
+        }
+        StartHour.SelectedIndex = _settings.WorkingHourStart ?? 9;
+        EndHour.SelectedIndex = _settings.WorkingHourEnd ?? 17;
+    }
+
+    private void PopulateInterval()
+    {
+        foreach (var (label, minutes) in Intervals)
+            IntervalBox.Items.Add(new ComboBoxItem { Content = label, Tag = minutes });
+
+        var match = Array.FindIndex(Intervals, i => i.Minutes == _settings.IntervalMinutes);
+        IntervalBox.SelectedIndex = match >= 0 ? match : 1; // default to 30 min
+    }
+
+    private void PopulateDays()
+    {
+        foreach (var (label, day) in Days)
+        {
+            var pill = new ToggleButton
+            {
+                Content = label,
+                Style = (Style)Resources["DayPill"],
+                IsChecked = _settings.ActiveDays.Contains(day),
+                Tag = day,
+            };
+            DayRow.Children.Add(pill);
+        }
+    }
+
+    private void OnSave(object sender, RoutedEventArgs e)
+    {
+        var start = SelectedHour(StartHour);
+        var end = SelectedHour(EndHour);
+        var interval = SelectedTag<int>(IntervalBox);
+
+        var days = DayRow.Children.OfType<ToggleButton>()
+            .Where(p => p.IsChecked == true)
+            .Select(p => (DayOfWeek)p.Tag!)
+            .ToList();
+
+        if (days.Count == 0)
+        {
+            MessageBox.Show("Pick at least one day.", "Schedule",
+                MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        _settings.WorkingHourStart = start;
+        _settings.WorkingHourEnd = end;
+        _settings.IntervalMinutes = interval;
+        _settings.ActiveDays = days;
+
+        Saved = true;
+        Close();
+    }
+
+    private static int SelectedHour(ComboBox box) => (int)((ComboBoxItem)box.SelectedItem).Tag!;
+    private static T SelectedTag<T>(ComboBox box) => (T)((ComboBoxItem)box.SelectedItem).Tag!;
+
+    private static string FormatHour(int h)
+    {
+        var period = h < 12 ? "AM" : "PM";
+        var display = h % 12 == 0 ? 12 : h % 12;
+        return $"{display}:00 {period}";
+    }
+}

--- a/SourceBase.Desktop/Settings/SettingsWindow.xaml.cs
+++ b/SourceBase.Desktop/Settings/SettingsWindow.xaml.cs
@@ -43,6 +43,7 @@ public partial class SettingsWindow : Window
         PopulateHours();
         PopulateInterval();
         PopulateDays();
+        PauseDuringVideoBox.IsChecked = _settings.PauseDuringVideo;
 
         MouseLeftButtonDown += (_, e) => { if (e.ButtonState == MouseButtonState.Pressed) DragMove(); };
         CancelButton.Click += (_, _) => Close();
@@ -107,6 +108,7 @@ public partial class SettingsWindow : Window
         _settings.WorkingHourEnd = end;
         _settings.IntervalMinutes = interval;
         _settings.ActiveDays = days;
+        _settings.PauseDuringVideo = PauseDuringVideoBox.IsChecked == true;
 
         Saved = true;
         Close();

--- a/SourceBase.Desktop/Settings/SettingsWindow.xaml.cs
+++ b/SourceBase.Desktop/Settings/SettingsWindow.xaml.cs
@@ -44,6 +44,9 @@ public partial class SettingsWindow : Window
         PopulateInterval();
         PopulateDays();
         PauseDuringVideoBox.IsChecked = _settings.PauseDuringVideo;
+        ApiUrlBox.Text = _settings.ApiBaseUrl ?? string.Empty;
+        AccessTokenBox.Text = _settings.ApiToken ?? string.Empty;
+        RefreshTokenBox.Text = _settings.ApiRefreshToken ?? string.Empty;
 
         MouseLeftButtonDown += (_, e) => { if (e.ButtonState == MouseButtonState.Pressed) DragMove(); };
         CancelButton.Click += (_, _) => Close();
@@ -109,6 +112,9 @@ public partial class SettingsWindow : Window
         _settings.IntervalMinutes = interval;
         _settings.ActiveDays = days;
         _settings.PauseDuringVideo = PauseDuringVideoBox.IsChecked == true;
+        _settings.ApiBaseUrl = NullIfEmpty(ApiUrlBox.Text);
+        _settings.ApiToken = NullIfEmpty(AccessTokenBox.Text);
+        _settings.ApiRefreshToken = NullIfEmpty(RefreshTokenBox.Text);
 
         Saved = true;
         Close();
@@ -116,6 +122,8 @@ public partial class SettingsWindow : Window
 
     private static int SelectedHour(ComboBox box) => (int)((ComboBoxItem)box.SelectedItem).Tag!;
     private static T SelectedTag<T>(ComboBox box) => (T)((ComboBoxItem)box.SelectedItem).Tag!;
+
+    private static string? NullIfEmpty(string? s) => string.IsNullOrWhiteSpace(s) ? null : s.Trim();
 
     private static string FormatHour(int h)
     {

--- a/SourceBase.Desktop/Settings/SettingsWindow.xaml.cs
+++ b/SourceBase.Desktop/Settings/SettingsWindow.xaml.cs
@@ -1,7 +1,10 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Media;
 using SourceBase.Desktop.Models;
 
 namespace SourceBase.Desktop.Settings;
@@ -51,6 +54,7 @@ public partial class SettingsWindow : Window
         MouseLeftButtonDown += (_, e) => { if (e.ButtonState == MouseButtonState.Pressed) DragMove(); };
         CancelButton.Click += (_, _) => Close();
         SaveButton.Click += OnSave;
+        TestButton.Click += OnTestConnection;
     }
 
     private void PopulateHours()
@@ -122,6 +126,55 @@ public partial class SettingsWindow : Window
 
     private static int SelectedHour(ComboBox box) => (int)((ComboBoxItem)box.SelectedItem).Tag!;
     private static T SelectedTag<T>(ComboBox box) => (T)((ComboBoxItem)box.SelectedItem).Tag!;
+
+    private async void OnTestConnection(object sender, RoutedEventArgs e)
+    {
+        var url = NullIfEmpty(ApiUrlBox.Text);
+        var token = NullIfEmpty(AccessTokenBox.Text);
+
+        if (url is null || token is null)
+        {
+            SetTestResult("Enter API URL and Access Token first.", false);
+            return;
+        }
+
+        TestButton.IsEnabled = false;
+        TestResultText.Foreground = new SolidColorBrush(Color.FromRgb(0x6B, 0x72, 0x80));
+        TestResultText.Text = "Testing…";
+        TestResultText.Visibility = Visibility.Visible;
+
+        try
+        {
+            using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            var response = await client.GetAsync($"{url.TrimEnd('/')}/api/auth/info");
+            if (response.IsSuccessStatusCode)
+                SetTestResult("Connected ✓", success: true);
+            else
+                SetTestResult($"Failed ({(int)response.StatusCode})", success: false);
+        }
+        catch (TaskCanceledException)
+        {
+            SetTestResult("Timed out", success: false);
+        }
+        catch (Exception ex)
+        {
+            SetTestResult($"Error: {ex.Message}", success: false);
+        }
+        finally
+        {
+            TestButton.IsEnabled = true;
+        }
+    }
+
+    private void SetTestResult(string text, bool success)
+    {
+        TestResultText.Text = text;
+        TestResultText.Foreground = new SolidColorBrush(success
+            ? Color.FromRgb(0x16, 0xA3, 0x4A)
+            : Color.FromRgb(0xDC, 0x26, 0x26));
+        TestResultText.Visibility = Visibility.Visible;
+    }
 
     private static string? NullIfEmpty(string? s) => string.IsNullOrWhiteSpace(s) ? null : s.Trim();
 

--- a/SourceBase.Desktop/SourceBase.Desktop.csproj
+++ b/SourceBase.Desktop/SourceBase.Desktop.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
 		<TargetFramework>net10.0-windows</TargetFramework>
+		<EnableWindowsTargeting>true</EnableWindowsTargeting>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseWPF>true</UseWPF>

--- a/SourceBase.Desktop/SourceBase.Desktop.csproj
+++ b/SourceBase.Desktop/SourceBase.Desktop.csproj
@@ -9,9 +9,12 @@
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 		<RootNamespace>SourceBase.Desktop</RootNamespace>
 		<AssemblyName>SourceBase.Desktop</AssemblyName>
-		<!-- single-file friendly publish defaults; override on the CLI as needed -->
-		<RuntimeIdentifier Condition="'$(PublishSingleFile)' == 'true'">win-x64</RuntimeIdentifier>
-		<SelfContained Condition="'$(PublishSingleFile)' == 'true'">true</SelfContained>
+		<!-- publish defaults: dotnet publish -c Release -->
+		<PublishSingleFile>true</PublishSingleFile>
+		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
+		<SelfContained>false</SelfContained>
+		<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+		<PublishDir>Artifacts\</PublishDir>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/SourceBase.Desktop/SourceBase.Desktop.csproj
+++ b/SourceBase.Desktop/SourceBase.Desktop.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>WinExe</OutputType>
+		<TargetFramework>net10.0-windows</TargetFramework>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<UseWPF>true</UseWPF>
+		<ApplicationManifest>app.manifest</ApplicationManifest>
+		<RootNamespace>SourceBase.Desktop</RootNamespace>
+		<AssemblyName>SourceBase.Desktop</AssemblyName>
+		<!-- single-file friendly publish defaults; override on the CLI as needed -->
+		<RuntimeIdentifier Condition="'$(PublishSingleFile)' == 'true'">win-x64</RuntimeIdentifier>
+		<SelfContained Condition="'$(PublishSingleFile)' == 'true'">true</SelfContained>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<!-- Modern WPF tray-icon library (NOTIFYICON). Hardcodet.NotifyIcon.Wpf is the classic alternative. -->
+		<PackageReference Include="H.NotifyIcon.Wpf" />
+	</ItemGroup>
+
+</Project>

--- a/SourceBase.Desktop/app.manifest
+++ b/SourceBase.Desktop/app.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2,permonitor</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/SourceBase.Domain/Entities/HabitEntity.cs
+++ b/SourceBase.Domain/Entities/HabitEntity.cs
@@ -1,0 +1,9 @@
+namespace SourceBase.Domain.Entities;
+
+public class HabitEntity : BaseAuditableEntity
+{
+    public required string Name { get; set; }
+    public string? Icon { get; set; }
+    public Guid? UserId { get; set; }
+    public bool IsSystem { get; set; }
+}

--- a/SourceBase.Domain/Entities/HabitLogEntity.cs
+++ b/SourceBase.Domain/Entities/HabitLogEntity.cs
@@ -1,0 +1,12 @@
+namespace SourceBase.Domain.Entities;
+
+public enum HabitLogAction { HabitStarted, Dismissed, Snoozed, SuppressedVideo }
+
+public class HabitLogEntity : BaseAuditableEntity
+{
+    public Guid UserId { get; set; }
+    public string? HabitId { get; set; }
+    public string? HabitName { get; set; }
+    public HabitLogAction Action { get; set; }
+    public DateTime OccurredAt { get; set; }
+}

--- a/SourceBase.Domain/Entities/HabitLogEntity.cs
+++ b/SourceBase.Domain/Entities/HabitLogEntity.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace SourceBase.Domain.Entities;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum HabitLogAction { HabitStarted, Dismissed, Snoozed, SuppressedVideo }
 
 public class HabitLogEntity : BaseAuditableEntity

--- a/SourceBase.Infrastructure/DbContexts/ApplicationDbContext.cs
+++ b/SourceBase.Infrastructure/DbContexts/ApplicationDbContext.cs
@@ -38,6 +38,8 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
 
     public DbSet<GoldPriceEntity> GoldPrices { get; set; }
 
+    public DbSet<HabitLogEntity> HabitLogs { get; set; }
+
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         optionsBuilder.AddInterceptors(new ApplicationDbContextHistoryInterceptor(currentUser, dateTime));

--- a/SourceBase.Infrastructure/DbContexts/ApplicationDbContext.cs
+++ b/SourceBase.Infrastructure/DbContexts/ApplicationDbContext.cs
@@ -40,6 +40,8 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
 
     public DbSet<HabitLogEntity> HabitLogs { get; set; }
 
+    public DbSet<HabitEntity> Habits { get; set; }
+
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         optionsBuilder.AddInterceptors(new ApplicationDbContextHistoryInterceptor(currentUser, dateTime));
@@ -75,6 +77,26 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
             .HasIndex(x => new { x.Source, x.RecordedAt })
             .IsUnique();
 
+    }
+
+    private static void SeedHabits(DbContext context)
+    {
+        var defaults = new List<(string Name, string Icon)>
+        {
+            ("Walk",         "🚶"),
+            ("Drink Water",  "💧"),
+            ("Read",         "📖"),
+            ("Exercise",     "🏋️"),
+            ("Meditate",     "🧘"),
+        };
+
+        foreach (var (name, icon) in defaults)
+        {
+            var exists = context.Set<HabitEntity>().Any(h => h.IsSystem && h.Name == name);
+            if (!exists)
+                context.Set<HabitEntity>().Add(new HabitEntity { Id = Guid.NewGuid(), Name = name, Icon = icon, IsSystem = true, UserId = null });
+        }
+        context.SaveChanges();
     }
 
     #region Helper Methods
@@ -141,6 +163,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
 
         SeedCategories(context);
         SeedIcons(context);
+        SeedHabits(context);
     }
 
     private static void SeedCategories(DbContext context)

--- a/SourceBase.Infrastructure/Migrations/20260629083734_AddHabits.Designer.cs
+++ b/SourceBase.Infrastructure/Migrations/20260629083734_AddHabits.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SourceBase.Infrastructure.DbContexts;
@@ -11,9 +12,11 @@ using SourceBase.Infrastructure.DbContexts;
 namespace SourceBase.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260629083734_AddHabits")]
+    partial class AddHabits
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SourceBase.Infrastructure/Migrations/20260629083734_AddHabits.cs
+++ b/SourceBase.Infrastructure/Migrations/20260629083734_AddHabits.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SourceBase.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddHabits : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "HabitLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    HabitId = table.Column<string>(type: "text", nullable: true, collation: "case_insensitive"),
+                    HabitName = table.Column<string>(type: "text", nullable: true, collation: "case_insensitive"),
+                    Action = table.Column<string>(type: "text", nullable: false),
+                    OccurredAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedOn = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<string>(type: "text", nullable: true, collation: "case_insensitive"),
+                    UpdatedOn = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true, collation: "case_insensitive")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_HabitLogs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Habits",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "text", nullable: false, collation: "case_insensitive"),
+                    Icon = table.Column<string>(type: "text", nullable: true, collation: "case_insensitive"),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    IsSystem = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedOn = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<string>(type: "text", nullable: true, collation: "case_insensitive"),
+                    UpdatedOn = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true, collation: "case_insensitive")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Habits", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "HabitLogs");
+
+            migrationBuilder.DropTable(
+                name: "Habits");
+        }
+    }
+}

--- a/SourceBase.Tests/Features/HabitLogs/CreateHabitLogsTests.cs
+++ b/SourceBase.Tests/Features/HabitLogs/CreateHabitLogsTests.cs
@@ -3,7 +3,6 @@ using System.Net.Http.Json;
 using Shouldly;
 using SourceBase.Application.Features.HabitLogs;
 using SourceBase.Application.Shared;
-using SourceBase.Domain.Entities;
 using SourceBase.Tests.Infrastructure;
 using Xunit;
 

--- a/SourceBase.Tests/Features/HabitLogs/CreateHabitLogsTests.cs
+++ b/SourceBase.Tests/Features/HabitLogs/CreateHabitLogsTests.cs
@@ -1,0 +1,156 @@
+using System.Net;
+using System.Net.Http.Json;
+using Shouldly;
+using SourceBase.Application.Features.HabitLogs;
+using SourceBase.Application.Shared;
+using SourceBase.Domain.Entities;
+using SourceBase.Tests.Infrastructure;
+using Xunit;
+
+namespace SourceBase.Tests.Features.HabitLogs;
+
+public class CreateHabitLogsTests(WebAppFactory factory) : IClassFixture<WebAppFactory>
+{
+    [Fact(DisplayName = "HLOG-CREATE-001: CreateHabitLogs_WithoutToken_ReturnsUnauthorized")]
+    public async Task CreateHabitLogs_WithoutToken_ReturnsUnauthorized()
+    {
+        // Arrange
+        var client = factory.CreateClient();
+
+        // Act
+        var response = await client.PostAsJsonAsync(CreateHabitLogsEndpoint.Route, new
+        {
+            entries = new[] { new { action = "HabitStarted", occurredAt = DateTime.UtcNow } }
+        });
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "HLOG-CREATE-002: CreateHabitLogs_WithSingleEntry_ReturnsOkWithId")]
+    public async Task CreateHabitLogs_WithSingleEntry_ReturnsOkWithId()
+    {
+        // Arrange
+        var client = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+
+        // Act
+        var response = await client.PostAsJsonAsync(CreateHabitLogsEndpoint.Route, new
+        {
+            entries = new[]
+            {
+                new { habitId = "walk", habitName = "Short Walk", action = "HabitStarted", occurredAt = DateTime.UtcNow }
+            }
+        });
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<CreateHabitLogsResponse>();
+        body!.Ids.ShouldHaveSingleItem();
+        body.Ids[0].ShouldNotBe(Guid.Empty);
+    }
+
+    [Fact(DisplayName = "HLOG-CREATE-003: CreateHabitLogs_WithMultipleEntries_ReturnsBatchIds")]
+    public async Task CreateHabitLogs_WithMultipleEntries_ReturnsBatchIds()
+    {
+        // Arrange
+        var client = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+        var now = DateTime.UtcNow;
+
+        // Act
+        var response = await client.PostAsJsonAsync(CreateHabitLogsEndpoint.Route, new
+        {
+            entries = new object[]
+            {
+                new { habitId = "walk",        habitName = "Short Walk",  action = "HabitStarted", occurredAt = now },
+                new { habitId = "drink-water", habitName = "Drink Water", action = "HabitStarted", occurredAt = now },
+                new { action = "Dismissed", occurredAt = now },
+            }
+        });
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<CreateHabitLogsResponse>();
+        body!.Ids.Count.ShouldBe(3);
+        body.Ids.ShouldAllBe(id => id != Guid.Empty);
+    }
+
+    [Fact(DisplayName = "HLOG-CREATE-004: CreateHabitLogs_WithEmptyEntries_ReturnsBadRequest")]
+    public async Task CreateHabitLogs_WithEmptyEntries_ReturnsBadRequest()
+    {
+        // Arrange
+        var client = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+
+        // Act
+        var response = await client.PostAsJsonAsync(CreateHabitLogsEndpoint.Route, new
+        {
+            entries = Array.Empty<object>()
+        });
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "HLOG-CREATE-005: CreateHabitLogs_WithMissingOccurredAt_ReturnsBadRequest")]
+    public async Task CreateHabitLogs_WithMissingOccurredAt_ReturnsBadRequest()
+    {
+        // Arrange
+        var client = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+
+        // Act — DateTime.MinValue is treated as empty by NotEmpty() validator
+        var response = await client.PostAsJsonAsync(CreateHabitLogsEndpoint.Route, new
+        {
+            entries = new[] { new { action = "HabitStarted", occurredAt = DateTime.MinValue } }
+        });
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "HLOG-CREATE-006: CreateHabitLogs_WithAllActionTypes_ReturnsOk")]
+    public async Task CreateHabitLogs_WithAllActionTypes_ReturnsOk()
+    {
+        // Arrange
+        var client = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+        var now = DateTime.UtcNow;
+
+        // Act
+        var response = await client.PostAsJsonAsync(CreateHabitLogsEndpoint.Route, new
+        {
+            entries = new[]
+            {
+                new { action = "HabitStarted",    occurredAt = now },
+                new { action = "Dismissed",        occurredAt = now },
+                new { action = "Snoozed",          occurredAt = now },
+                new { action = "SuppressedVideo",  occurredAt = now },
+            }
+        });
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<CreateHabitLogsResponse>();
+        body!.Ids.Count.ShouldBe(4);
+    }
+
+    [Fact(DisplayName = "HLOG-CREATE-007: CreateHabitLogs_ScopedToCurrentUser_NotVisibleToOtherUser")]
+    public async Task CreateHabitLogs_ScopedToCurrentUser_NotVisibleToOtherUser()
+    {
+        // Arrange
+        var userA = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+        var userB = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+
+        var createResponse = await userA.PostAsJsonAsync(CreateHabitLogsEndpoint.Route, new
+        {
+            entries = new[] { new { action = "Dismissed", occurredAt = DateTime.UtcNow } }
+        });
+        var createBody = await createResponse.Content.ReadFromJsonAsync<CreateHabitLogsResponse>();
+        var createdId = createBody!.Ids[0];
+
+        // Act — userB fetches their own logs (should be empty)
+        var response = await userB.GetAsync(GetHabitLogsEndpoint.Route);
+        var body = await response.Content.ReadFromJsonAsync<PagingResponse<GetHabitLogResponse>>();
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        body!.Items.ShouldNotContain(l => l.Id == createdId);
+    }
+}

--- a/SourceBase.Tests/Features/HabitLogs/DeleteHabitLogTests.cs
+++ b/SourceBase.Tests/Features/HabitLogs/DeleteHabitLogTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using System.Net.Http.Json;
+using Shouldly;
+using SourceBase.Application.Features.HabitLogs;
+using SourceBase.Application.Shared;
+using SourceBase.Tests.Infrastructure;
+using Xunit;
+
+namespace SourceBase.Tests.Features.HabitLogs;
+
+public class DeleteHabitLogTests(WebAppFactory factory) : IClassFixture<WebAppFactory>
+{
+    [Fact(DisplayName = "HLOG-DELETE-001: DeleteHabitLog_WithoutToken_ReturnsUnauthorized")]
+    public async Task DeleteHabitLog_WithoutToken_ReturnsUnauthorized()
+    {
+        // Arrange
+        var client = factory.CreateClient();
+
+        // Act
+        var response = await client.DeleteAsync(DeleteHabitLogEndpoint.Route.WithId(Guid.NewGuid()));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "HLOG-DELETE-002: DeleteHabitLog_WithValidId_ReturnsOkAndRemovesLog")]
+    public async Task DeleteHabitLog_WithValidId_ReturnsOkAndRemovesLog()
+    {
+        // Arrange
+        var client = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+
+        var createResponse = await client.PostAsJsonAsync(CreateHabitLogsEndpoint.Route, new
+        {
+            entries = new[] { new { action = "Dismissed", occurredAt = DateTime.UtcNow } }
+        });
+        var created = await createResponse.Content.ReadFromJsonAsync<CreateHabitLogsResponse>();
+        var id = created!.Ids[0];
+
+        // Act
+        var deleteResponse = await client.DeleteAsync(DeleteHabitLogEndpoint.Route.WithId(id));
+
+        // Assert
+        deleteResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await deleteResponse.Content.ReadFromJsonAsync<DeleteHabitLogResponse>();
+        body!.Success.ShouldBeTrue();
+
+        // Confirm log is gone
+        var listResponse = await client.GetAsync(GetHabitLogsEndpoint.Route);
+        var list = await listResponse.Content.ReadFromJsonAsync<PagingResponse<GetHabitLogResponse>>();
+        list!.Items.ShouldNotContain(l => l.Id == id);
+    }
+
+    [Fact(DisplayName = "HLOG-DELETE-003: DeleteHabitLog_WithUnknownId_ReturnsNotFound")]
+    public async Task DeleteHabitLog_WithUnknownId_ReturnsNotFound()
+    {
+        // Arrange
+        var client = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+
+        // Act
+        var response = await client.DeleteAsync(DeleteHabitLogEndpoint.Route.WithId(Guid.NewGuid()));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "HLOG-DELETE-004: DeleteHabitLog_WithOtherUsersLog_ReturnsNotFound")]
+    public async Task DeleteHabitLog_WithOtherUsersLog_ReturnsNotFound()
+    {
+        // Arrange
+        var owner = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+        var other = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+
+        var createResponse = await owner.PostAsJsonAsync(CreateHabitLogsEndpoint.Route, new
+        {
+            entries = new[] { new { action = "Snoozed", occurredAt = DateTime.UtcNow } }
+        });
+        var created = await createResponse.Content.ReadFromJsonAsync<CreateHabitLogsResponse>();
+        var id = created!.Ids[0];
+
+        // Act — different user tries to delete owner's log
+        var response = await other.DeleteAsync(DeleteHabitLogEndpoint.Route.WithId(id));
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+}

--- a/SourceBase.Tests/Features/HabitLogs/GetHabitLogsTests.cs
+++ b/SourceBase.Tests/Features/HabitLogs/GetHabitLogsTests.cs
@@ -1,0 +1,192 @@
+using System.Net;
+using System.Net.Http.Json;
+using Shouldly;
+using SourceBase.Application.Features.HabitLogs;
+using SourceBase.Application.Shared;
+using SourceBase.Domain.Entities;
+using SourceBase.Tests.Infrastructure;
+using Xunit;
+
+namespace SourceBase.Tests.Features.HabitLogs;
+
+public class GetHabitLogsTests(WebAppFactory factory) : IClassFixture<WebAppFactory>
+{
+    [Fact(DisplayName = "HLOG-GET-001: GetHabitLogs_WithoutToken_ReturnsUnauthorized")]
+    public async Task GetHabitLogs_WithoutToken_ReturnsUnauthorized()
+    {
+        // Arrange
+        var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync(GetHabitLogsEndpoint.Route);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "HLOG-GET-002: GetHabitLogs_WithNoFilters_ReturnsAllLogsForCurrentUser")]
+    public async Task GetHabitLogs_WithNoFilters_ReturnsAllLogsForCurrentUser()
+    {
+        // Arrange
+        var client = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+        var now = DateTime.UtcNow;
+
+        await client.PostAsJsonAsync(CreateHabitLogsEndpoint.Route, new
+        {
+            entries = new[]
+            {
+                new { action = "HabitStarted", occurredAt = now },
+                new { action = "Snoozed",      occurredAt = now },
+            }
+        });
+
+        // Act
+        var response = await client.GetAsync(GetHabitLogsEndpoint.Route);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<PagingResponse<GetHabitLogResponse>>();
+        body!.Total.ShouldBe(2);
+        body.Items.Count.ShouldBe(2);
+    }
+
+    [Fact(DisplayName = "HLOG-GET-003: GetHabitLogs_FilteredByAction_ReturnsOnlyMatchingLogs")]
+    public async Task GetHabitLogs_FilteredByAction_ReturnsOnlyMatchingLogs()
+    {
+        // Arrange
+        var client = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+        var now = DateTime.UtcNow;
+
+        await client.PostAsJsonAsync(CreateHabitLogsEndpoint.Route, new
+        {
+            entries = new[]
+            {
+                new { action = "HabitStarted", occurredAt = now },
+                new { action = "HabitStarted", occurredAt = now },
+                new { action = "Dismissed",    occurredAt = now },
+            }
+        });
+
+        // Act
+        var response = await client.GetAsync($"{GetHabitLogsEndpoint.Route}?action=HabitStarted");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<PagingResponse<GetHabitLogResponse>>();
+        body!.Total.ShouldBe(2);
+        body.Items.ShouldAllBe(l => l.Action == HabitLogAction.HabitStarted);
+    }
+
+    [Fact(DisplayName = "HLOG-GET-004: GetHabitLogs_FilteredByDateRange_ReturnsLogsInRange")]
+    public async Task GetHabitLogs_FilteredByDateRange_ReturnsLogsInRange()
+    {
+        // Arrange
+        var client = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+        var old = new DateTime(2024, 1, 15, 10, 0, 0, DateTimeKind.Utc);
+        var recent = DateTime.UtcNow;
+
+        await client.PostAsJsonAsync(CreateHabitLogsEndpoint.Route, new
+        {
+            entries = new[]
+            {
+                new { action = "Dismissed", occurredAt = old },
+                new { action = "Snoozed",   occurredAt = recent },
+            }
+        });
+
+        var cutoff = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var from = Uri.EscapeDataString(cutoff.ToString("o"));
+
+        // Act — only logs on or after 2025-01-01 should appear
+        var response = await client.GetAsync($"{GetHabitLogsEndpoint.Route}?from={from}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<PagingResponse<GetHabitLogResponse>>();
+        body!.Items.ShouldAllBe(l => l.OccurredAt >= cutoff);
+        body.Items.ShouldNotContain(l => l.OccurredAt < cutoff);
+    }
+
+    [Fact(DisplayName = "HLOG-GET-005: GetHabitLogs_Paginated_RespectsLimitAndPage")]
+    public async Task GetHabitLogs_Paginated_RespectsLimitAndPage()
+    {
+        // Arrange
+        var client = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+        var now = DateTime.UtcNow;
+
+        await client.PostAsJsonAsync(CreateHabitLogsEndpoint.Route, new
+        {
+            entries = Enumerable.Range(0, 5)
+                .Select(_ => new { action = "Snoozed", occurredAt = now })
+                .ToArray<object>()
+        });
+
+        // Act
+        var page1Response = await client.GetAsync($"{GetHabitLogsEndpoint.Route}?page=1&limit=2");
+        var page2Response = await client.GetAsync($"{GetHabitLogsEndpoint.Route}?page=2&limit=2");
+
+        // Assert
+        page1Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        page2Response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var page1 = await page1Response.Content.ReadFromJsonAsync<PagingResponse<GetHabitLogResponse>>();
+        var page2 = await page2Response.Content.ReadFromJsonAsync<PagingResponse<GetHabitLogResponse>>();
+
+        page1!.Items.Count.ShouldBe(2);
+        page2!.Items.Count.ShouldBe(2);
+        page1.Total.ShouldBe(5);
+        page2.Total.ShouldBe(5);
+    }
+
+    [Fact(DisplayName = "HLOG-GET-006: GetHabitLogs_DoesNotReturnOtherUsersLogs")]
+    public async Task GetHabitLogs_DoesNotReturnOtherUsersLogs()
+    {
+        // Arrange
+        var userA = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+        var userB = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+
+        var createResponse = await userA.PostAsJsonAsync(CreateHabitLogsEndpoint.Route, new
+        {
+            entries = new[] { new { action = "Dismissed", occurredAt = DateTime.UtcNow } }
+        });
+        var created = await createResponse.Content.ReadFromJsonAsync<CreateHabitLogsResponse>();
+        var createdId = created!.Ids[0];
+
+        // Act — userB should see an empty list
+        var response = await userB.GetAsync(GetHabitLogsEndpoint.Route);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<PagingResponse<GetHabitLogResponse>>();
+        body!.Items.ShouldNotContain(l => l.Id == createdId);
+    }
+
+    [Fact(DisplayName = "HLOG-GET-007: GetHabitLogs_ReturnsCorrectFields")]
+    public async Task GetHabitLogs_ReturnsCorrectFields()
+    {
+        // Arrange
+        var client = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+        var occurredAt = new DateTime(2025, 3, 15, 9, 30, 0, DateTimeKind.Utc);
+
+        await client.PostAsJsonAsync(CreateHabitLogsEndpoint.Route, new
+        {
+            entries = new[]
+            {
+                new { habitId = "walk", habitName = "Short Walk", action = "HabitStarted", occurredAt }
+            }
+        });
+
+        // Act
+        var response = await client.GetAsync(GetHabitLogsEndpoint.Route);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<PagingResponse<GetHabitLogResponse>>();
+        var log = body!.Items.Single();
+        log.HabitId.ShouldBe("walk");
+        log.HabitName.ShouldBe("Short Walk");
+        log.Action.ShouldBe(HabitLogAction.HabitStarted);
+        log.OccurredAt.ShouldBe(occurredAt);
+        log.Id.ShouldNotBe(Guid.Empty);
+    }
+}

--- a/SourceBase.Web/Pages/HabitLogs/HabitLogs.razor
+++ b/SourceBase.Web/Pages/HabitLogs/HabitLogs.razor
@@ -1,0 +1,185 @@
+@page "/habit-logs"
+@attribute [Authorize]
+@inject ApiHttpClient Api
+
+<!-- Header -->
+<div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4">
+    <h1 class="text-xl font-bold text-gray-900">Habit Logs</h1>
+    <div class="flex items-center gap-2">
+        @if (_weekOffset != 0)
+        {
+            <button class="btn-secondary btn-sm" @onclick="GoToCurrentWeek">Today</button>
+        }
+        <button class="btn-secondary btn-sm" @onclick="PrevWeek" title="Previous week">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+            </svg>
+        </button>
+        <span class="text-sm font-medium text-gray-700 whitespace-nowrap min-w-[160px] text-center">@WeekRangeLabel()</span>
+        <button class="btn-secondary btn-sm" @onclick="NextWeek" title="Next week">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+        </button>
+    </div>
+</div>
+
+@if (_loading)
+{
+    <LoadingSpinner />
+}
+else if (_error is not null)
+{
+    <div class="rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">@_error</div>
+}
+else
+{
+    <!-- Calendar — horizontal scroll on mobile S/M -->
+    <div class="overflow-x-auto rounded-xl border border-gray-200 shadow-sm">
+        <div class="min-w-[600px]">
+
+            <!-- Day header row -->
+            <div class="grid grid-cols-7 bg-gray-50 border-b border-gray-200">
+                @for (var d = 0; d < 7; d++)
+                {
+                    var day = WeekStart.AddDays(d);
+                    var isToday = day.Date == DateTime.Today;
+                    <div class="flex flex-col items-center py-3 border-r last:border-r-0 border-gray-200 @(isToday ? "bg-indigo-50" : "")">
+                        <span class="text-[11px] font-semibold uppercase tracking-wide @(isToday ? "text-indigo-500" : "text-gray-400")">@day.ToString("ddd")</span>
+                        <span class="text-lg font-bold mt-0.5 @(isToday ? "text-indigo-700" : "text-gray-700")">@day.Day</span>
+                    </div>
+                }
+            </div>
+
+            <!-- Log cells -->
+            <div class="grid grid-cols-7 bg-white">
+                @for (var d = 0; d < 7; d++)
+                {
+                    var day = WeekStart.AddDays(d);
+                    var isToday = day.Date == DateTime.Today;
+                    var entries = LogsForDay(day);
+                    <div class="min-h-[120px] p-1.5 border-r last:border-r-0 border-gray-100 space-y-1 @(isToday ? "bg-indigo-50/20" : "")">
+                        @if (!entries.Any())
+                        {
+                            <div class="flex items-center justify-center h-full pt-8 text-gray-200 text-xs select-none">—</div>
+                        }
+                        else
+                        {
+                            @foreach (var log in entries)
+                            {
+                                <div class="rounded-md px-1.5 py-1 border @EntryClass(log.Action)">
+                                    <div class="text-[10px] opacity-60 leading-none mb-0.5">@log.OccurredAt.ToLocalTime().ToString("HH:mm")</div>
+                                    <div class="text-[11px] font-semibold truncate leading-tight">@EntryLabel(log)</div>
+                                </div>
+                            }
+                        }
+                    </div>
+                }
+            </div>
+
+        </div>
+    </div>
+
+    <!-- Summary legend -->
+    @if (_logs.Count > 0)
+    {
+        <div class="mt-3 flex flex-wrap gap-x-5 gap-y-2">
+            @foreach (var g in _logs.GroupBy(l => l.Action).OrderBy(g => g.Key))
+            {
+                <div class="flex items-center gap-1.5 text-xs text-gray-500">
+                    <span class="w-2.5 h-2.5 rounded-sm shrink-0 @LegendDotClass(g.Key)"></span>
+                    @ActionGroupLabel(g.Key) — <strong class="text-gray-800 ml-0.5">@g.Count()</strong>
+                </div>
+            }
+            <div class="flex items-center gap-1.5 text-xs text-gray-400 ml-auto">Total: <strong class="text-gray-700">@_logs.Count</strong></div>
+        </div>
+    }
+    else
+    {
+        <div class="mt-4 text-center text-sm text-gray-400">No habit logs for this week.</div>
+    }
+}
+
+@code {
+    private int _weekOffset;
+    private List<HabitLogResponse> _logs = [];
+    private bool _loading = true;
+    private string? _error;
+
+    private DateTime WeekStart => GetWeekStart(DateTime.Today).AddDays(_weekOffset * 7);
+    private DateTime WeekEnd => WeekStart.AddDays(6);
+
+    private static DateTime GetWeekStart(DateTime date)
+    {
+        var dow = (int)date.DayOfWeek;
+        return date.AddDays(-(dow == 0 ? 6 : dow - 1)).Date;
+    }
+
+    private string WeekRangeLabel()
+    {
+        var start = WeekStart;
+        var end = WeekEnd;
+        return start.Month == end.Month
+            ? $"{start:MMM d} – {end.Day}, {end.Year}"
+            : $"{start:MMM d} – {end:MMM d}, {end.Year}";
+    }
+
+    protected override async Task OnInitializedAsync() => await LoadAsync();
+
+    private async Task PrevWeek() { _weekOffset--; await LoadAsync(); }
+
+    private async Task NextWeek() { _weekOffset++; await LoadAsync(); }
+
+    private async Task GoToCurrentWeek() { _weekOffset = 0; await LoadAsync(); }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        _error = null;
+        var from = WeekStart.ToUniversalTime();
+        var to = WeekEnd.AddDays(1).AddTicks(-1).ToUniversalTime();
+        var (data, err) = await Api.GetHabitLogsAsync(from, to);
+        _logs = data?.Items ?? [];
+        if (err is not null) _error = err.Message ?? "Failed to load habit logs.";
+        _loading = false;
+    }
+
+    private IEnumerable<HabitLogResponse> LogsForDay(DateTime day) =>
+        _logs.Where(l => l.OccurredAt.ToLocalTime().Date == day.Date);
+
+    private static string EntryClass(string action) => action switch
+    {
+        "HabitStarted"    => "bg-emerald-50 border-emerald-200 text-emerald-800",
+        "Dismissed"       => "bg-gray-50 border-gray-200 text-gray-500",
+        "Snoozed"         => "bg-amber-50 border-amber-200 text-amber-800",
+        "SuppressedVideo" => "bg-violet-50 border-violet-200 text-violet-700",
+        _                 => "bg-gray-50 border-gray-200 text-gray-500",
+    };
+
+    private static string LegendDotClass(string action) => action switch
+    {
+        "HabitStarted"    => "bg-emerald-400",
+        "Dismissed"       => "bg-gray-400",
+        "Snoozed"         => "bg-amber-400",
+        "SuppressedVideo" => "bg-violet-400",
+        _                 => "bg-gray-400",
+    };
+
+    private static string EntryLabel(HabitLogResponse log) => log.Action switch
+    {
+        "HabitStarted"    => log.HabitName ?? "Habit",
+        "Dismissed"       => "Dismissed",
+        "Snoozed"         => "Snoozed",
+        "SuppressedVideo" => "Skipped (video)",
+        _                 => log.Action,
+    };
+
+    private static string ActionGroupLabel(string action) => action switch
+    {
+        "HabitStarted"    => "Habit started",
+        "Dismissed"       => "Dismissed",
+        "Snoozed"         => "Snoozed",
+        "SuppressedVideo" => "Skipped (video)",
+        _                 => action,
+    };
+}

--- a/SourceBase.Web/Pages/HabitLogs/HabitLogs.razor
+++ b/SourceBase.Web/Pages/HabitLogs/HabitLogs.razor
@@ -2,6 +2,33 @@
 @attribute [Authorize]
 @inject ApiHttpClient Api
 
+<!-- Quick log habit cards -->
+@if (_habits.Count > 0)
+{
+    <div class="mb-5">
+        <div class="flex items-center justify-between mb-2">
+            <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Quick Log</span>
+            <a href="/habit-logs/habits" class="text-xs text-indigo-500 hover:text-indigo-700">Manage habits →</a>
+        </div>
+        <div class="flex flex-wrap gap-2">
+            @foreach (var habit in _habits)
+            {
+                <button class="flex items-center gap-2 px-3 py-2 rounded-xl border border-gray-200 bg-white hover:border-indigo-400 hover:bg-indigo-50 transition-colors text-sm font-medium text-gray-700 disabled:opacity-50"
+                        @onclick="LogHabit(habit)" disabled="@_loggingHabitId.HasValue" title="Log @habit.Name">
+                    <span class="text-base leading-none">@HabitIcon(habit.Icon)</span>
+                    <span class="truncate max-w-[100px]">@habit.Name</span>
+                </button>
+            }
+        </div>
+    </div>
+}
+else if (!_loading && _habitsLoaded)
+{
+    <div class="mb-5 p-3 rounded-xl border border-dashed border-gray-200 text-center text-sm text-gray-400">
+        No habits configured. <a href="/habit-logs/habits" class="text-indigo-500 hover:underline">Add some habits</a> to enable quick logging.
+    </div>
+}
+
 <!-- Header -->
 <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4">
     <h1 class="text-xl font-bold text-gray-900">Habit Logs</h1>
@@ -103,8 +130,11 @@ else
 @code {
     private int _weekOffset;
     private List<HabitLogResponse> _logs = [];
+    private List<HabitItemResponse> _habits = [];
     private bool _loading = true;
+    private bool _habitsLoaded;
     private string? _error;
+    private Guid? _loggingHabitId;
 
     private DateTime WeekStart => GetWeekStart(DateTime.Today).AddDays(_weekOffset * 7);
     private DateTime WeekEnd => WeekStart.AddDays(6);
@@ -124,7 +154,19 @@ else
             : $"{start:MMM d} – {end:MMM d}, {end.Year}";
     }
 
-    protected override async Task OnInitializedAsync() => await LoadAsync();
+    protected override async Task OnInitializedAsync()
+    {
+        var habitsTask = LoadHabitsAsync();
+        var logsTask = LoadAsync();
+        await Task.WhenAll(habitsTask, logsTask);
+    }
+
+    private async Task LoadHabitsAsync()
+    {
+        var (data, _) = await Api.GetHabitsAsync();
+        _habits = data ?? [];
+        _habitsLoaded = true;
+    }
 
     private async Task PrevWeek() { _weekOffset--; await LoadAsync(); }
 
@@ -143,6 +185,16 @@ else
         if (err is not null) _error = err.Message ?? "Failed to load habit logs.";
         _loading = false;
     }
+
+    private Func<Task> LogHabit(HabitItemResponse habit) => async () =>
+    {
+        _loggingHabitId = habit.Id;
+        await Api.LogHabitAsync(habit.Id.ToString(), habit.Name, "HabitStarted");
+        _loggingHabitId = null;
+        await LoadAsync();
+    };
+
+    private static string HabitIcon(string? icon) => string.IsNullOrWhiteSpace(icon) ? "💪" : icon;
 
     private IEnumerable<HabitLogResponse> LogsForDay(DateTime day) =>
         _logs.Where(l => l.OccurredAt.ToLocalTime().Date == day.Date);

--- a/SourceBase.Web/Pages/HabitLogs/Habits.razor
+++ b/SourceBase.Web/Pages/HabitLogs/Habits.razor
@@ -1,0 +1,197 @@
+@page "/habit-logs/habits"
+@attribute [Authorize]
+@inject ApiHttpClient Api
+
+@if (!string.IsNullOrEmpty(_error))
+{
+    <div class="mb-4 rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">@_error</div>
+}
+
+<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
+    <div>
+        <h1 class="text-2xl font-bold text-gray-900">Habits</h1>
+        <div class="text-sm text-gray-500 mt-1">Manage your habit types for quick logging.</div>
+    </div>
+    <button class="btn-primary self-start sm:self-auto" @onclick="OpenCreate">
+        <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+        </svg>
+        Add Habit
+    </button>
+</div>
+
+@if (_loading)
+{
+    <LoadingSpinner />
+}
+else
+{
+    <div class="card !p-0 overflow-hidden">
+        @if (_habits.Count == 0)
+        {
+            <div class="text-sm text-gray-400 py-10 text-center">No habits yet. Add one to get started.</div>
+        }
+        else
+        {
+            <div class="divide-y divide-gray-100">
+                @foreach (var habit in _habits)
+                {
+                    <div class="flex items-center justify-between gap-3 px-4 py-3">
+                        <div class="flex items-center gap-3 min-w-0">
+                            <div class="w-10 h-10 rounded-full bg-indigo-50 flex items-center justify-center text-xl shrink-0">
+                                @HabitIcon(habit.Icon)
+                            </div>
+                            <div class="min-w-0">
+                                <div class="font-medium text-gray-900 truncate">@habit.Name</div>
+                                @if (habit.IsSystem)
+                                {
+                                    <span class="badge-blue text-xs">System</span>
+                                }
+                            </div>
+                        </div>
+                        <div class="flex items-center gap-2 shrink-0">
+                            @if (habit.IsSystem)
+                            {
+                                <span class="text-gray-300" title="System habit — cannot be modified">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 10-8 0v4h8z" />
+                                    </svg>
+                                </span>
+                            }
+                            else
+                            {
+                                <button class="text-gray-400 hover:text-indigo-600 transition-colors" @onclick="OpenEdit(habit)" title="Edit">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                                    </svg>
+                                </button>
+                                <button class="text-gray-400 hover:text-red-600 transition-colors" @onclick="ConfirmDelete(habit)" title="Delete">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                    </svg>
+                                </button>
+                            }
+                        </div>
+                    </div>
+                }
+            </div>
+        }
+    </div>
+}
+
+@if (_showForm)
+{
+    <div class="fixed inset-0 z-40 flex items-center justify-center">
+        <div class="absolute inset-0 bg-black/40" @onclick="CloseForm"></div>
+        <div class="relative bg-white rounded-lg shadow-xl w-full max-w-md mx-4 p-6">
+            <h2 class="text-lg font-semibold text-gray-900 mb-4">@(_editing is null ? "Add Habit" : "Edit Habit")</h2>
+            @if (!string.IsNullOrEmpty(_formError))
+            {
+                <div class="mb-3 rounded-md bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">@_formError</div>
+            }
+            <div class="space-y-4">
+                <div>
+                    <label class="form-label">Name *</label>
+                    <input @bind="_name" class="form-input" placeholder="e.g. Morning Run" />
+                </div>
+                <div>
+                    <label class="form-label">Icon (emoji)</label>
+                    <input @bind="_icon" class="form-input" placeholder="e.g. 🏃" maxlength="8" />
+                    <div class="text-xs text-gray-400 mt-1">Paste any emoji to use as the habit icon.</div>
+                </div>
+            </div>
+            <div class="flex justify-end gap-3 mt-5">
+                <button class="btn-secondary" @onclick="CloseForm">Cancel</button>
+                <button class="btn-primary" @onclick="SaveAsync" disabled="@_saving">@(_saving ? "Saving…" : "Save")</button>
+            </div>
+        </div>
+    </div>
+}
+
+<ConfirmDialog IsVisible="_showDelete"
+               Title="Delete habit"
+               Message="@($"Delete '{_deleting?.Name}'?")"
+               OnConfirm="DeleteAsync"
+               OnCancel="CancelDelete" />
+
+@code {
+    private List<HabitItemResponse> _habits = [];
+    private bool _loading = true;
+    private string? _error;
+
+    private bool _showForm;
+    private HabitItemResponse? _editing;
+    private string _name = string.Empty;
+    private string _icon = string.Empty;
+    private string? _formError;
+    private bool _saving;
+
+    private bool _showDelete;
+    private HabitItemResponse? _deleting;
+
+    protected override async Task OnInitializedAsync() => await LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        _error = null;
+        var (data, err) = await Api.GetHabitsAsync();
+        _habits = data ?? [];
+        if (err is not null) _error = err.Message ?? "Failed to load habits.";
+        _loading = false;
+    }
+
+    private void OpenCreate()
+    {
+        _editing = null;
+        _name = string.Empty;
+        _icon = string.Empty;
+        _formError = null;
+        _showForm = true;
+    }
+
+    private Action OpenEdit(HabitItemResponse habit) => () =>
+    {
+        _editing = habit;
+        _name = habit.Name;
+        _icon = habit.Icon ?? string.Empty;
+        _formError = null;
+        _showForm = true;
+    };
+
+    private void CloseForm() => _showForm = false;
+
+    private async Task SaveAsync()
+    {
+        _formError = null;
+        if (string.IsNullOrWhiteSpace(_name)) { _formError = "Name is required."; return; }
+
+        _saving = true;
+        var icon = string.IsNullOrWhiteSpace(_icon) ? null : _icon.Trim();
+        var err = _editing is null
+            ? await Api.CreateHabitAsync(_name.Trim(), icon)
+            : await Api.UpdateHabitAsync(_editing.Id, _name.Trim(), icon);
+
+        if (err is not null) { _formError = err.Message ?? "Failed to save habit."; _saving = false; return; }
+
+        _showForm = false;
+        _saving = false;
+        await LoadAsync();
+    }
+
+    private Action ConfirmDelete(HabitItemResponse habit) => () => { _deleting = habit; _showDelete = true; };
+
+    private void CancelDelete() { _showDelete = false; _deleting = null; }
+
+    private async Task DeleteAsync()
+    {
+        if (_deleting is null) return;
+        _showDelete = false;
+        var err = await Api.DeleteHabitAsync(_deleting.Id);
+        if (err is not null) _error = err.Message ?? "Failed to delete habit.";
+        else await LoadAsync();
+        _deleting = null;
+    }
+
+    private static string HabitIcon(string? icon) => string.IsNullOrWhiteSpace(icon) ? "💪" : icon;
+}

--- a/SourceBase.Web/Services/ApiHttpClient.cs
+++ b/SourceBase.Web/Services/ApiHttpClient.cs
@@ -391,6 +391,14 @@ public class ApiHttpClient(HttpClient http, BlazorAuthStateProvider auth, ToastS
     public Task<ErrorResponse?> ClearAllNotificationsAsync() =>
         ExecuteAsync(() => AuthorizedRequest(HttpMethod.Delete, "/api/notifications"));
 
+    // ── Habit Logs ────────────────────────────────────────────────────────────
+
+    public Task<(PagingResponse<HabitLogResponse>? data, ErrorResponse? error)> GetHabitLogsAsync(DateTime from, DateTime to)
+    {
+        var url = $"/api/habit-logs?from={Uri.EscapeDataString(from.ToString("o"))}&to={Uri.EscapeDataString(to.ToString("o"))}&limit=500&orderBy=OccurredAt&order=Asc";
+        return ExecuteAsync<PagingResponse<HabitLogResponse>>(() => AuthorizedRequest(HttpMethod.Get, url));
+    }
+
     // ── Gold Prices ───────────────────────────────────────────────────────────
 
     public Task<(PagingResponse<GoldPriceResponse>? data, ErrorResponse? error)> GetGoldPricesAsync(int page = 1, int limit = 20, string? source = null, string? dateFrom = null, string? dateTo = null, bool? latest = null)
@@ -433,3 +441,4 @@ public sealed record GetNotificationsResponse(List<NotificationResponse> Items, 
 public sealed record IconResponse(Guid Id, string Value, string Name, string Group, int SortOrder, bool IsSystem);
 public sealed record IconUploadUrlResponse(string UploadUrl, string IconUrl, string ContentType);
 public sealed record GoldPriceResponse(Guid Id, string Source, decimal BuyPrice, decimal SellPrice, DateTime RecordedAt);
+public sealed record HabitLogResponse(Guid Id, string? HabitId, string? HabitName, string Action, DateTime OccurredAt, DateTime? CreatedOn);

--- a/SourceBase.Web/Services/ApiHttpClient.cs
+++ b/SourceBase.Web/Services/ApiHttpClient.cs
@@ -391,6 +391,23 @@ public class ApiHttpClient(HttpClient http, BlazorAuthStateProvider auth, ToastS
     public Task<ErrorResponse?> ClearAllNotificationsAsync() =>
         ExecuteAsync(() => AuthorizedRequest(HttpMethod.Delete, "/api/notifications"));
 
+    // ── Habits ────────────────────────────────────────────────────────────────
+
+    public Task<(List<HabitItemResponse>? data, ErrorResponse? error)> GetHabitsAsync() =>
+        ExecuteAsync<List<HabitItemResponse>>(() => AuthorizedRequest(HttpMethod.Get, "/api/habits"));
+
+    public Task<ErrorResponse?> CreateHabitAsync(string name, string? icon) =>
+        ExecuteAsync(() => AuthorizedRequest(HttpMethod.Post, "/api/habits", new { name, icon }));
+
+    public Task<ErrorResponse?> UpdateHabitAsync(Guid id, string? name = null, string? icon = null) =>
+        ExecuteAsync(() => AuthorizedRequest(HttpMethod.Patch, $"/api/habits/{id}", new { name, icon }));
+
+    public Task<ErrorResponse?> DeleteHabitAsync(Guid id) =>
+        ExecuteAsync(() => AuthorizedRequest(HttpMethod.Delete, $"/api/habits/{id}"));
+
+    public Task<ErrorResponse?> LogHabitAsync(string habitId, string habitName, string action) =>
+        ExecuteAsync(() => AuthorizedRequest(HttpMethod.Post, "/api/habit-logs", new { entries = new[] { new { habitId, habitName, action, occurredAt = DateTime.UtcNow } } }));
+
     // ── Habit Logs ────────────────────────────────────────────────────────────
 
     public Task<(PagingResponse<HabitLogResponse>? data, ErrorResponse? error)> GetHabitLogsAsync(DateTime from, DateTime to)
@@ -442,3 +459,4 @@ public sealed record IconResponse(Guid Id, string Value, string Name, string Gro
 public sealed record IconUploadUrlResponse(string UploadUrl, string IconUrl, string ContentType);
 public sealed record GoldPriceResponse(Guid Id, string Source, decimal BuyPrice, decimal SellPrice, DateTime RecordedAt);
 public sealed record HabitLogResponse(Guid Id, string? HabitId, string? HabitName, string Action, DateTime OccurredAt, DateTime? CreatedOn);
+public sealed record HabitItemResponse(Guid Id, string Name, string? Icon, bool IsSystem);

--- a/SourceBase.Web/wwwroot/appsettings.json
+++ b/SourceBase.Web/wwwroot/appsettings.json
@@ -34,7 +34,14 @@
         {
             "title": "Habit Logs",
             "url": "/habit-logs",
-            "icon": "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01\" />"
+            "icon": "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01\" />",
+            "subPages": [
+                {
+                    "title": "Habits",
+                    "url": "/habit-logs/habits",
+                    "icon": "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z\" />"
+                }
+            ]
         },
         {
             "title": "Gold Prices",

--- a/SourceBase.Web/wwwroot/appsettings.json
+++ b/SourceBase.Web/wwwroot/appsettings.json
@@ -32,6 +32,11 @@
             "icon": "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z\" />"
         },
         {
+            "title": "Habit Logs",
+            "url": "/habit-logs",
+            "icon": "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01\" />"
+        },
+        {
             "title": "Gold Prices",
             "url": "/gold-prices",
             "icon": "<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z\" />"

--- a/SourceBase.slnx
+++ b/SourceBase.slnx
@@ -7,6 +7,7 @@
   </Folder>
   <Project Path="SourceBase.Api/SourceBase.Api.csproj" />
   <Project Path="SourceBase.Application/SourceBase.Application.csproj" />
+  <Project Path="SourceBase.Desktop/SourceBase.Desktop.csproj" />
   <Project Path="SourceBase.Domain/SourceBase.Domain.csproj" />
   <Project Path="SourceBase.Infrastructure/SourceBase.Infrastructure.csproj" />
   <Project Path="SourceBase.Tests/SourceBase.Tests.csproj" />


### PR DESCRIPTION
## Summary

Introduces **SourceBase.Desktop**, a Windows tray application that nudges users to take regular rest breaks. On a configurable interval (default 30 minutes), it displays a fullscreen overlay with a white modal showing habit cards (emoji or image-based) for the user to pick from during a ~5-minute rest period.

This is **Phase 1: local-only**. Settings and habit picks are stored locally in `%AppData%\SourceBase.Desktop\settings.json`. Phase 2 will sync with the SourceBase API.

## Key Changes

- **Models** (`Habit.cs`, `AppSettings.cs`)
  - `Habit`: serializable model with emoji/image support, enabled flag, and accent color
  - `AppSettings`: user-configurable settings (interval, rest length, working hours, active days, blocked processes for video detection)
  - Default habits: Drink Water, Push Up, Stretching, Rest Eyes, Short Walk, Deep Breaths

- **Settings** (`SettingsStore.cs`, `SettingsWindow.xaml(.cs)`)
  - JSON persistence to `%AppData%\SourceBase.Desktop\settings.json`
  - Settings UI: interval/rest/working-hours dropdowns, day-of-week toggles, video pause checkbox
  - Graceful fallback to defaults on corrupt file

- **Scheduling** (`RestScheduler.cs`, `PresentationDetector.cs`)
  - `RestScheduler`: 20-second tick timer that fires `DueForRest` when interval elapsed, within working hours, and on active days
  - `PresentationDetector`: suppresses overlay during fullscreen video/games via Windows notification state + fullscreen window detection + blocked process names (stremio, vlc, netflix, spotify, etc.)
  - Snooze support (configurable defer duration)

- **Overlay** (`OverlayWindow.xaml(.cs)`)
  - Fullscreen dimmed backdrop with centered white modal (720px wide)
  - Habit cards: 140×140px with emoji/image, name, and selection checkmark badge
  - Card selection toggles accent color and background tint
  - "Start rest" button (disabled until ≥1 habit picked) shows countdown timer
  - Fade-in animation on load; scale transform on modal
  - Keyboard support (Esc to close)

- **App** (`App.xaml(.cs)`)
  - Single-instance mutex to prevent multiple app instances
  - Tray icon with custom vector glyphs (mug, pause, leaf, cup, droplet) drawn via GDI+
  - Context menu: "Take a break now", "Settings", "Exit"
  - Wires `RestScheduler` and `OverlayWindow` together
  - Auto-starts at login (placeholder; Phase 2 will add registry toggle)

- **Project setup**
  - New `SourceBase.Desktop.csproj` targeting `net10.0-windows` with WPF
  - H.NotifyIcon.Wpf for modern tray icon support
  - Added to solution file

## Notable Implementation Details

- **No nested ifs**: Early returns and guard clauses throughout (e.g., `RestScheduler.OnTick`, `PresentationDetector` checks)
- **Primary constructors**: Used in `OverlayWindow`, `SettingsWindow`, `RestScheduler`, `SettingsStore`
- **Emoji rendering**: Explicit `FontFamily="Segoe UI Emoji"` to avoid mono glyph fallback
- **Multi-monitor support**: Overlay covers virtual screen (all monitors); fullscreen detection compares against virtual screen dimensions
- **Graceful degradation**: All P/Invoke calls wrapped in try-catch; corrupt settings file falls back to defaults rather than crashing
- **Vector tray icons**: Custom GDI+ drawing (no font dependency) for crisp 32×32 icons at any DPI

## Testing

- Manual: double-click tray icon to preview overlay immediately
- Settings persist across restarts
- Snooze resets countdown to snooze duration
- Video detection suppresses overlay for 2 minutes, then retries (not a

https://claude.ai/code/session_01Vv6aZXsJ6XmstcKPvr8HRS