### PR TITLE
chore: align API git tag prefix to api-v1.x convention

### DIFF
--- a/.github/workflows/api-publish.yml
+++ b/.github/workflows/api-publish.yml
@@ -49,12 +49,12 @@ jobs:
       - name: Calculate next version
         id: calc
         run: |
-          latest=$(git tag -l 'v1.*' | sort -V | tail -1)
+          latest=$(git tag -l 'api-v1.*' | sort -V | tail -1)
           if [ -z "$latest" ]; then
-            new_version="v1.0"
+            new_version="api-v1.0"
           else
-            x=$(echo "$latest" | sed 's/v1\.//')
-            new_version="v1.$((x + 1))"
+            x=$(echo "$latest" | sed 's/api-v1\.//')
+            new_version="api-v1.$((x + 1))"
           fi
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
           echo "Next API version: $new_version"


### PR DESCRIPTION
Matches the web-v1.x and desktop-v1.x tagging convention used by the
other publish workflows.