### PR TITLE
Configure cache headers and routing for Blazor WASM

### DIFF
--- a/SourceBase.Web/wwwroot/_headers
+++ b/SourceBase.Web/wwwroot/_headers
@@ -1,0 +1,21 @@
+/_framework/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.wasm
+  Cache-Control: public, max-age=31536000, immutable
+
+/app.min.css
+  Cache-Control: public, max-age=86400
+
+/app.js
+  Cache-Control: public, max-age=86400
+
+/index.html
+  Cache-Control: no-cache
+
+/appsettings.json
+  Cache-Control: no-cache
+
+/appsettings.Production.json
+  Cache-Control: no-cache
+

--- a/SourceBase.Web/wwwroot/_redirects
+++ b/SourceBase.Web/wwwroot/_redirects
@@ -1,1 +1,4 @@
+/_framework/* /_framework/:splat 200
+/*.wasm /:splat 200
+/index.html /index.html 200
 /* /index.html 200


### PR DESCRIPTION
## Summary
Add HTTP caching headers and routing rules for the Blazor WebAssembly SPA to optimize performance and ensure proper cache invalidation strategies.

## Key Changes
- **New `_headers` file**: Configure cache control policies for different asset types
  - Framework and WASM files: 1-year immutable cache (long-lived, content-addressed)
  - CSS and JS bundles: 24-hour cache (versioned assets)
  - Configuration files (`appsettings.json`, `appsettings.Production.json`) and `index.html`: no-cache (always revalidate)
- **Updated `_redirects` file**: Add explicit routing rules
  - Preserve framework and WASM file routing
  - Ensure SPA fallback to `index.html` for client-side routing

## Implementation Details
The caching strategy follows best practices for Blazor WASM:
- Immutable cache for content-addressed assets (framework DLLs, WASM binaries)
- Short TTL for application bundles to enable quick updates
- No-cache for configuration and entry point to ensure fresh config on each visit
- Explicit routing rules prevent conflicts and ensure proper asset delivery

https://claude.ai/code/session_01PeztNZL1ALsuJYDBrNEvjZ