### PR TITLE
feat(desktop): add check for update button next to version label

### DIFF
--- a/SourceBase.Desktop/Settings/SettingsWindow.xaml
+++ b/SourceBase.Desktop/Settings/SettingsWindow.xaml
@@ -203,6 +203,20 @@
             <Setter Property="Background" Value="#F9FAFB"/>
         </Style>
 
+        <Style x:Key="IconButton" TargetType="Button">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
         <!-- Day-of-week pill toggle -->
         <Style x:Key="DayPill" TargetType="ToggleButton">
             <Setter Property="Width" Value="58"/>
@@ -253,7 +267,13 @@
                         <Ellipse x:Name="StatusDot" Width="8" Height="8" VerticalAlignment="Center" Margin="0,0,5,0"/>
                         <TextBlock x:Name="StatusText" FontSize="11" FontWeight="SemiBold" VerticalAlignment="Center" Cursor="Hand"/>
                     </StackPanel>
-                    <TextBlock x:Name="VersionLabel" FontSize="12" Foreground="#9CA3AF" HorizontalAlignment="Right"/>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                        <TextBlock x:Name="VersionLabel" FontSize="12" Foreground="#9CA3AF" VerticalAlignment="Center"/>
+                        <Button x:Name="CheckUpdateButton" Style="{StaticResource IconButton}"
+                                Margin="5,0,0,0" VerticalAlignment="Center" ToolTip="Check for updates">
+                            <TextBlock x:Name="RefreshIcon" Text="↻" FontSize="14" Foreground="#9CA3AF"/>
+                        </Button>
+                    </StackPanel>
                 </StackPanel>
             </Grid>
             <TextBlock Text="Schedule and API connection"

--- a/SourceBase.Desktop/Settings/SettingsWindow.xaml.cs
+++ b/SourceBase.Desktop/Settings/SettingsWindow.xaml.cs
@@ -66,11 +66,13 @@ public partial class SettingsWindow : Window
         ApplyStatusIndicator();
         ApplyApiUiState();
 
+        UpdateButton.Click += OnUpdateClicked;
+        CheckUpdateButton.Click += OnCheckUpdate;
+
         if (UpdateService.PendingUpdate is { } update)
         {
             UpdateBanner.Visibility = Visibility.Visible;
             UpdateAvailableLabel.Text = $"Update available: v{update.Version}";
-            UpdateButton.Click += OnUpdateClicked;
         }
     }
 
@@ -228,6 +230,29 @@ public partial class SettingsWindow : Window
     }
 
     // ── OTA update ────────────────────────────────────────────────────────────
+
+    private async void OnCheckUpdate(object sender, RoutedEventArgs e)
+    {
+        CheckUpdateButton.IsEnabled = false;
+        RefreshIcon.Text = "…";
+        await UpdateService.CheckAsync();
+        CheckUpdateButton.IsEnabled = true;
+
+        if (UpdateService.PendingUpdate is { } update)
+        {
+            UpdateBanner.Visibility = Visibility.Visible;
+            UpdateAvailableLabel.Text = $"Update available: v{update.Version}";
+            RefreshIcon.Text = "↻";
+        }
+        else
+        {
+            RefreshIcon.Text = "✓";
+            RefreshIcon.Foreground = new SolidColorBrush(Color.FromRgb(0x16, 0xA3, 0x4A));
+            await Task.Delay(2000);
+            RefreshIcon.Text = "↻";
+            RefreshIcon.Foreground = new SolidColorBrush(Color.FromRgb(0x9C, 0xA3, 0xAF));
+        }
+    }
 
     private async void OnUpdateClicked(object sender, RoutedEventArgs e)
     {


### PR DESCRIPTION
Adds a ↻ refresh icon button next to the version text in the Jupiter
Settings window. Clicking it calls UpdateService.CheckAsync(), shows the
update banner if a newer release is found, or briefly flashes ✓ in green
if already up to date.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WrHdKnSk9eKP54aoHCQhND