### PR TITLE
feat(habit-logs): add IgnoreActions filter param and exclude Dismissed on web

### DIFF
--- a/SourceBase.Application/Features/HabitLogs/GetHabitLogs.cs
+++ b/SourceBase.Application/Features/HabitLogs/GetHabitLogs.cs
@@ -4,7 +4,7 @@ using SourceBase.Application.Shared.Interfaces;
 
 namespace SourceBase.Application.Features.HabitLogs;
 
-public record GetHabitLogsRequest(HabitLogAction? Action, DateTime? From, DateTime? To, int? Page, int? Limit, PagingOrder? Order, GetHabitLogsOrderBy? OrderBy)
+public record GetHabitLogsRequest(HabitLogAction? Action, List<HabitLogAction>? IgnoreActions, DateTime? From, DateTime? To, int? Page, int? Limit, PagingOrder? Order, GetHabitLogsOrderBy? OrderBy)
     : PagingRequest(Page, Limit, Order, OrderBy?.ToString());
 
 public record GetHabitLogResponse(Guid Id, string? HabitId, string? HabitName, HabitLogAction Action, DateTime OccurredAt, DateTime? CreatedOn);
@@ -25,6 +25,7 @@ public class GetHabitLogsHandler(IDbContext dbContext, ICurrentUser currentUser)
         var logs = await dbContext.HabitLogs
             .Where(x => x.UserId == currentUser.UserId
                 && (request.Action == null || x.Action == request.Action)
+                && (request.IgnoreActions == null || !request.IgnoreActions.Contains(x.Action))
                 && (request.From == null || x.OccurredAt >= request.From)
                 && (request.To == null || x.OccurredAt <= request.To))
             .PaginateAsync(x => new GetHabitLogResponse(x.Id, x.HabitId, x.HabitName, x.Action, x.OccurredAt, x.CreatedOn), request, ct);

--- a/SourceBase.Application/Features/HabitLogs/GetHabitLogs.cs
+++ b/SourceBase.Application/Features/HabitLogs/GetHabitLogs.cs
@@ -4,7 +4,7 @@ using SourceBase.Application.Shared.Interfaces;
 
 namespace SourceBase.Application.Features.HabitLogs;
 
-public record GetHabitLogsRequest(HabitLogAction? Action, List<HabitLogAction>? IgnoreActions, DateTime? From, DateTime? To, int? Page, int? Limit, PagingOrder? Order, GetHabitLogsOrderBy? OrderBy)
+public record GetHabitLogsRequest(HabitLogAction? Action, List<HabitLogAction>? Ignore, DateTime? From, DateTime? To, int? Page, int? Limit, PagingOrder? Order, GetHabitLogsOrderBy? OrderBy)
     : PagingRequest(Page, Limit, Order, OrderBy?.ToString());
 
 public record GetHabitLogResponse(Guid Id, string? HabitId, string? HabitName, HabitLogAction Action, DateTime OccurredAt, DateTime? CreatedOn);
@@ -25,7 +25,7 @@ public class GetHabitLogsHandler(IDbContext dbContext, ICurrentUser currentUser)
         var logs = await dbContext.HabitLogs
             .Where(x => x.UserId == currentUser.UserId
                 && (request.Action == null || x.Action == request.Action)
-                && (request.IgnoreActions == null || !request.IgnoreActions.Contains(x.Action))
+                && (request.Ignore == null || !request.Ignore.Contains(x.Action))
                 && (request.From == null || x.OccurredAt >= request.From)
                 && (request.To == null || x.OccurredAt <= request.To))
             .PaginateAsync(x => new GetHabitLogResponse(x.Id, x.HabitId, x.HabitName, x.Action, x.OccurredAt, x.CreatedOn), request, ct);

--- a/SourceBase.Application/Features/HabitLogs/GetHabitLogs.cs
+++ b/SourceBase.Application/Features/HabitLogs/GetHabitLogs.cs
@@ -1,3 +1,4 @@
+using FluentValidation;
 using System.Text.Json.Serialization;
 using SourceBase.Application.Shared;
 using SourceBase.Application.Shared.Interfaces;
@@ -30,6 +31,14 @@ public class GetHabitLogsHandler(IDbContext dbContext, ICurrentUser currentUser)
                 && (request.To == null || x.OccurredAt <= request.To))
             .PaginateAsync(x => new GetHabitLogResponse(x.Id, x.HabitId, x.HabitName, x.Action, x.OccurredAt, x.CreatedOn), request, ct);
         return logs;
+    }
+}
+
+public class GetHabitLogsRequestValidator : AbstractValidator<GetHabitLogsRequest>
+{
+    public GetHabitLogsRequestValidator()
+    {
+        RuleFor(x => x.Ignore).Must(x => x is null || x.Count > 0).WithMessage("'Ignore' must not be empty.");
     }
 }
 

--- a/SourceBase.Tests/Features/HabitLogs/GetHabitLogsTests.cs
+++ b/SourceBase.Tests/Features/HabitLogs/GetHabitLogsTests.cs
@@ -161,6 +161,33 @@ public class GetHabitLogsTests(WebAppFactory factory) : IClassFixture<WebAppFact
         body!.Items.ShouldNotContain(l => l.Id == createdId);
     }
 
+    [Fact(DisplayName = "HLOG-GET-008: GetHabitLogs_WithIgnoreActions_ExcludesMatchingLogs")]
+    public async Task GetHabitLogs_WithIgnoreActions_ExcludesMatchingLogs()
+    {
+        // Arrange
+        var client = await factory.CreateAuthorizedClient($"hlog_{Guid.NewGuid():N}@test.com", "Test@1234!");
+        var now = DateTime.UtcNow;
+
+        await client.PostAsJsonAsync(CreateHabitLogsEndpoint.Route, new
+        {
+            entries = new[]
+            {
+                new { action = "HabitStarted", occurredAt = now },
+                new { action = "Dismissed",    occurredAt = now },
+                new { action = "Snoozed",      occurredAt = now },
+            }
+        });
+
+        // Act
+        var response = await client.GetAsync($"{GetHabitLogsEndpoint.Route}?ignoreActions=Dismissed");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<PagingResponse<GetHabitLogResponse>>();
+        body!.Total.ShouldBe(2);
+        body.Items.ShouldNotContain(l => l.Action == HabitLogAction.Dismissed);
+    }
+
     [Fact(DisplayName = "HLOG-GET-007: GetHabitLogs_ReturnsCorrectFields")]
     public async Task GetHabitLogs_ReturnsCorrectFields()
     {

--- a/SourceBase.Tests/Features/HabitLogs/GetHabitLogsTests.cs
+++ b/SourceBase.Tests/Features/HabitLogs/GetHabitLogsTests.cs
@@ -179,7 +179,7 @@ public class GetHabitLogsTests(WebAppFactory factory) : IClassFixture<WebAppFact
         });
 
         // Act
-        var response = await client.GetAsync($"{GetHabitLogsEndpoint.Route}?ignoreActions=Dismissed");
+        var response = await client.GetAsync($"{GetHabitLogsEndpoint.Route}?ignore=Dismissed");
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.OK);

--- a/SourceBase.Web/Services/ApiHttpClient.cs
+++ b/SourceBase.Web/Services/ApiHttpClient.cs
@@ -412,7 +412,7 @@ public class ApiHttpClient(HttpClient http, BlazorAuthStateProvider auth, ToastS
 
     public Task<(PagingResponse<HabitLogResponse>? data, ErrorResponse? error)> GetHabitLogsAsync(DateTime from, DateTime to)
     {
-        var url = $"/api/habit-logs?from={Uri.EscapeDataString(from.ToString("o"))}&to={Uri.EscapeDataString(to.ToString("o"))}&limit=500&orderBy=OccurredAt&order=Asc";
+        var url = $"/api/habit-logs?from={Uri.EscapeDataString(from.ToString("o"))}&to={Uri.EscapeDataString(to.ToString("o"))}&limit=500&orderBy=OccurredAt&order=Asc&ignoreActions=Dismissed";
         return ExecuteAsync<PagingResponse<HabitLogResponse>>(() => AuthorizedRequest(HttpMethod.Get, url));
     }
 

--- a/SourceBase.Web/Services/ApiHttpClient.cs
+++ b/SourceBase.Web/Services/ApiHttpClient.cs
@@ -412,7 +412,7 @@ public class ApiHttpClient(HttpClient http, BlazorAuthStateProvider auth, ToastS
 
     public Task<(PagingResponse<HabitLogResponse>? data, ErrorResponse? error)> GetHabitLogsAsync(DateTime from, DateTime to)
     {
-        var url = $"/api/habit-logs?from={Uri.EscapeDataString(from.ToString("o"))}&to={Uri.EscapeDataString(to.ToString("o"))}&limit=500&orderBy=OccurredAt&order=Asc&ignoreActions=Dismissed";
+        var url = $"/api/habit-logs?from={Uri.EscapeDataString(from.ToString("o"))}&to={Uri.EscapeDataString(to.ToString("o"))}&limit=500&orderBy=OccurredAt&order=Asc&ignore=Dismissed";
         return ExecuteAsync<PagingResponse<HabitLogResponse>>(() => AuthorizedRequest(HttpMethod.Get, url));
     }
 


### PR DESCRIPTION
- GetHabitLogsRequest gains List<HabitLogAction>? IgnoreActions; handler excludes matching entries in the EF query
- ApiHttpClient.GetHabitLogsAsync appends &ignoreActions=Dismissed so the calendar view no longer shows dismissed logs
- Added HLOG-GET-008 integration test verifying IgnoreActions excludes the specified action from results