### PR TITLE
Improve mobile responsiveness of profile button in header

### DIFF
--- a/SourceBase.Web/Layout/MainLayout.razor
+++ b/SourceBase.Web/Layout/MainLayout.razor
@@ -33,7 +33,7 @@
                 <AuthorizeView>
                     <Authorized>
                         <div class="relative">
-                            <button @onclick="ToggleProfile" class="flex items-center gap-2 px-3 py-1.5 rounded-md text-sm text-gray-700 hover:bg-gray-100 transition-colors">
+                            <button @onclick="ToggleProfile" class="flex items-center gap-2 px-1.5 md:px-3 py-1.5 rounded-md text-sm text-gray-700 hover:bg-gray-100 transition-colors">
                                 @if (!string.IsNullOrEmpty(AuthStateProvider.UserInfo?.AvatarUrl))
                                 {
                                     <img src="@AuthStateProvider.UserInfo.AvatarUrl" alt="Avatar" class="w-6 h-6 rounded-full object-cover shrink-0" />
@@ -44,8 +44,8 @@
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                                     </svg>
                                 }
-                                <span class="truncate max-w-25 font-semibold">@_displayName</span>
-                                <svg class="w-4 h-4 text-gray-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <span class="hidden md:inline truncate max-w-25 font-semibold">@_displayName</span>
+                                <svg class="hidden md:block w-4 h-4 text-gray-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
                                 </svg>
                             </button>


### PR DESCRIPTION
## Summary
Optimized the profile button in the main layout header for mobile devices by hiding the display name and dropdown chevron on smaller screens, and reducing horizontal padding on mobile while maintaining the full layout on medium screens and above.

## Key Changes
- Adjusted button padding: `px-3` → `px-1.5 md:px-3` to reduce horizontal space on mobile (320px+) while keeping full padding on `md` breakpoint and above
- Hidden display name on mobile: added `hidden md:inline` class to the username span
- Hidden dropdown chevron on mobile: added `hidden md:block` class to the SVG icon

## Implementation Details
These changes follow Tailwind CSS v4 responsive design patterns using breakpoint prefixes (`md:`), ensuring the profile button remains compact and usable on small mobile screens (Mobile S 320px / Mobile M 375px) while preserving the full UI on larger viewports. The button remains fully functional on all screen sizes.

https://claude.ai/code/session_01NVKZP73YZi4RGnpPchLbZ1