### PR TITLE
Add "Run at startup" setting to launch Jupiter on Windows boot

### DIFF
--- a/SourceBase.Desktop/Services/StartupService.cs
+++ b/SourceBase.Desktop/Services/StartupService.cs
@@ -1,0 +1,26 @@
+using Microsoft.Win32;
+
+namespace SourceBase.Desktop.Services;
+
+public static class StartupService
+{
+    private const string RegistryKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Run";
+    private const string AppName = "Jupiter";
+
+    public static void Apply(bool enable)
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(RegistryKey, writable: true);
+        if (key is null) return;
+
+        if (enable)
+            key.SetValue(AppName, $"\"{Environment.ProcessPath}\"");
+        else
+            key.DeleteValue(AppName, throwOnMissingValue: false);
+    }
+
+    public static bool IsEnabled()
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(RegistryKey, writable: false);
+        return key?.GetValue(AppName) is not null;
+    }
+}

--- a/SourceBase.Desktop/Settings/SettingsWindow.xaml
+++ b/SourceBase.Desktop/Settings/SettingsWindow.xaml
@@ -302,12 +302,23 @@
             <StackPanel x:Name="DayRow" Orientation="Horizontal" Margin="0,0,0,24"/>
 
             <!-- Pause during video -->
-            <CheckBox x:Name="PauseDuringVideoBox" Margin="0,0,0,32"
+            <CheckBox x:Name="PauseDuringVideoBox" Margin="0,0,0,16"
                       VerticalContentAlignment="Center" Cursor="Hand">
                 <StackPanel>
                     <TextBlock Text="Pause during video" FontSize="13" FontWeight="SemiBold"
                                Foreground="#374151"/>
                     <TextBlock Text="Skip reminders while watching fullscreen video or gaming"
+                               FontSize="12" Foreground="#9CA3AF" Margin="0,2,0,0"/>
+                </StackPanel>
+            </CheckBox>
+
+            <!-- Run at startup -->
+            <CheckBox x:Name="StartAtLoginBox" Margin="0,0,0,32"
+                      VerticalContentAlignment="Center" Cursor="Hand">
+                <StackPanel>
+                    <TextBlock Text="Run at startup" FontSize="13" FontWeight="SemiBold"
+                               Foreground="#374151"/>
+                    <TextBlock Text="Launch Jupiter automatically when Windows starts"
                                FontSize="12" Foreground="#9CA3AF" Margin="0,2,0,0"/>
                 </StackPanel>
             </CheckBox>

--- a/SourceBase.Desktop/Settings/SettingsWindow.xaml.cs
+++ b/SourceBase.Desktop/Settings/SettingsWindow.xaml.cs
@@ -51,6 +51,7 @@ public partial class SettingsWindow : Window
         PopulateInterval();
         PopulateDays();
         PauseDuringVideoBox.IsChecked = _settings.PauseDuringVideo;
+        StartAtLoginBox.IsChecked = StartupService.IsEnabled();
         ApiUrlBox.Text = _settings.ApiBaseUrl ?? string.Empty;
         UsernameBox.Text = _settings.ApiUsername ?? string.Empty;
         PasswordBox.Password = _settings.ApiPassword ?? string.Empty;
@@ -189,6 +190,8 @@ public partial class SettingsWindow : Window
         _settings.IntervalMinutes = interval;
         _settings.ActiveDays = days;
         _settings.PauseDuringVideo = PauseDuringVideoBox.IsChecked == true;
+        _settings.StartAtLogin = StartAtLoginBox.IsChecked == true;
+        StartupService.Apply(_settings.StartAtLogin);
 
         Saved = true;
         Close();


### PR DESCRIPTION
## Summary
Adds a new "Run at startup" feature that allows users to automatically launch Jupiter when Windows starts. This is implemented via Windows Registry integration in the Run key.

## Key Changes
- **New `StartupService`** — Static service that manages Windows Registry entries for startup configuration
  - `Apply(bool enable)` — Adds or removes the app from `HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Run`
  - `IsEnabled()` — Checks if the app is currently registered for startup
- **Settings UI** — Added checkbox in `SettingsWindow.xaml` with descriptive label and helper text
- **Settings binding** — Wired checkbox to `AppSettings.StartAtLogin` property and calls `StartupService.Apply()` on save
- **UI polish** — Adjusted margin on "Pause during video" checkbox to maintain consistent spacing

## Implementation Details
- Uses `Registry.CurrentUser` to avoid requiring admin privileges
- Gracefully handles missing registry key with null check
- `DeleteValue` uses `throwOnMissingValue: false` to prevent errors if entry doesn't exist
- Checkbox state is populated from registry on window load via `StartupService.IsEnabled()`

https://claude.ai/code/session_01Q7Spdonou4rxS1TDh72GAG