### PR TITLE
Display habit log counts on home dashboard

### DIFF
--- a/SourceBase.Application/Features/Habits/GetHabits.cs
+++ b/SourceBase.Application/Features/Habits/GetHabits.cs
@@ -20,15 +20,15 @@ public class GetHabitsHandler(IDbContext dbContext, ICurrentUser currentUser) : 
     public Task<List<HabitResponse>> Handle(GetHabitsRequest request, CancellationToken ct)
     {
         var userId = currentUser.UserId;
-        var logCounts = dbContext.HabitLogs
+        var habitCounts = dbContext.HabitLogs
             .Where(l => l.UserId == userId)
             .GroupBy(l => l.HabitId)
             .Select(g => new { HabitId = g.Key, Count = g.Count() });
 
         return dbContext.Habits
             .Where(h => h.IsSystem || h.UserId == userId)
-            .GroupJoin(logCounts, h => h.Id.ToString(), lc => lc.HabitId, (h, lcs) => new { h, lcs })
-            .SelectMany(x => x.lcs.DefaultIfEmpty(), (x, lc) => new HabitResponse(x.h.Id, x.h.Name, x.h.Icon, x.h.IsSystem, lc == null ? 0 : lc.Count))
+            .GroupJoin(habitCounts, h => h.Id.ToString(), hc => hc.HabitId, (h, hcs) => new { h, hcs })
+            .SelectMany(x => x.hcs.DefaultIfEmpty(), (x, hc) => new HabitResponse(x.h.Id, x.h.Name, x.h.Icon, x.h.IsSystem, hc == null ? 0 : hc.Count))
             .OrderByDescending(r => r.LogCount)
             .ToListAsync(ct);
     }

--- a/SourceBase.Application/Features/Habits/GetHabits.cs
+++ b/SourceBase.Application/Features/Habits/GetHabits.cs
@@ -17,24 +17,19 @@ public class GetHabitsEndpoint : IEndpoint
 
 public class GetHabitsHandler(IDbContext dbContext, ICurrentUser currentUser) : IRequestHandler<GetHabitsRequest, List<HabitResponse>>
 {
-    public async Task<List<HabitResponse>> Handle(GetHabitsRequest request, CancellationToken ct)
+    public Task<List<HabitResponse>> Handle(GetHabitsRequest request, CancellationToken ct)
     {
         var userId = currentUser.UserId;
-        var habits = await dbContext.Habits
-            .Where(h => h.IsSystem || h.UserId == userId)
-            .Select(h => new { h.Id, h.Name, h.Icon, h.IsSystem })
-            .ToListAsync(ct);
-
-        var habitIds = habits.Select(h => h.Id.ToString()).ToList();
-        var counts = await dbContext.HabitLogs
-            .Where(l => l.UserId == userId && habitIds.Contains(l.HabitId!))
+        var logCounts = dbContext.HabitLogs
+            .Where(l => l.UserId == userId)
             .GroupBy(l => l.HabitId)
-            .Select(g => new { HabitId = g.Key!, Count = g.Count() })
-            .ToDictionaryAsync(x => x.HabitId, x => x.Count, ct);
+            .Select(g => new { HabitId = g.Key, Count = g.Count() });
 
-        return habits
-            .Select(h => new HabitResponse(h.Id, h.Name, h.Icon, h.IsSystem, counts.GetValueOrDefault(h.Id.ToString(), 0)))
-            .OrderByDescending(h => h.LogCount)
-            .ToList();
+        return dbContext.Habits
+            .Where(h => h.IsSystem || h.UserId == userId)
+            .GroupJoin(logCounts, h => h.Id.ToString(), lc => lc.HabitId, (h, lcs) => new { h, lcs })
+            .SelectMany(x => x.lcs.DefaultIfEmpty(), (x, lc) => new HabitResponse(x.h.Id, x.h.Name, x.h.Icon, x.h.IsSystem, lc == null ? 0 : lc.Count))
+            .OrderByDescending(r => r.LogCount)
+            .ToListAsync(ct);
     }
 }

--- a/SourceBase.Application/Features/Habits/GetHabits.cs
+++ b/SourceBase.Application/Features/Habits/GetHabits.cs
@@ -4,7 +4,7 @@ using SourceBase.Application.Shared.Interfaces;
 namespace SourceBase.Application.Features.Habits;
 
 public record GetHabitsRequest;
-public record HabitResponse(Guid Id, string Name, string? Icon, bool IsSystem);
+public record HabitResponse(Guid Id, string Name, string? Icon, bool IsSystem, int LogCount);
 
 public class GetHabitsEndpoint : IEndpoint
 {
@@ -17,10 +17,24 @@ public class GetHabitsEndpoint : IEndpoint
 
 public class GetHabitsHandler(IDbContext dbContext, ICurrentUser currentUser) : IRequestHandler<GetHabitsRequest, List<HabitResponse>>
 {
-    public async Task<List<HabitResponse>> Handle(GetHabitsRequest request, CancellationToken ct) =>
-        await dbContext.Habits
-            .Where(h => h.IsSystem || h.UserId == currentUser.UserId)
-            .OrderBy(h => h.Name)
-            .Select(h => new HabitResponse(h.Id, h.Name, h.Icon, h.IsSystem))
+    public async Task<List<HabitResponse>> Handle(GetHabitsRequest request, CancellationToken ct)
+    {
+        var userId = currentUser.UserId;
+        var habits = await dbContext.Habits
+            .Where(h => h.IsSystem || h.UserId == userId)
+            .Select(h => new { h.Id, h.Name, h.Icon, h.IsSystem })
             .ToListAsync(ct);
+
+        var habitIds = habits.Select(h => h.Id.ToString()).ToList();
+        var counts = await dbContext.HabitLogs
+            .Where(l => l.UserId == userId && habitIds.Contains(l.HabitId!))
+            .GroupBy(l => l.HabitId)
+            .Select(g => new { HabitId = g.Key!, Count = g.Count() })
+            .ToDictionaryAsync(x => x.HabitId, x => x.Count, ct);
+
+        return habits
+            .Select(h => new HabitResponse(h.Id, h.Name, h.Icon, h.IsSystem, counts.GetValueOrDefault(h.Id.ToString(), 0)))
+            .OrderByDescending(h => h.LogCount)
+            .ToList();
+    }
 }

--- a/SourceBase.Web/Pages/Home.razor
+++ b/SourceBase.Web/Pages/Home.razor
@@ -96,6 +96,38 @@
     }
 </div>
 
+<!-- Habits cards row -->
+<div class="grid grid-cols-3 lg:grid-cols-5 gap-2 md:gap-4 mb-2 md:mb-4">
+    @if (_habitsLoading)
+    {
+        <div class="col-span-3 lg:col-span-5 text-sm text-gray-400">Loading…</div>
+    }
+    else if (_habits.Count == 0)
+    {
+        <div class="col-span-3 lg:col-span-5 text-sm text-gray-400 py-2">No habits yet.</div>
+    }
+    else
+    {
+        @for (var i = 0; i < _habits.Count; i++)
+        {
+            var habit = _habits[i];
+            var cardBg = HabitCardBgColors[i % HabitCardBgColors.Length];
+            var cardText = HabitCardTextColors[i % HabitCardTextColors.Length];
+            <div class="card p-2 md:p-4 flex flex-col gap-0 md:gap-2 @cardBg">
+                <div class="flex items-center gap-1">
+                    @if (!string.IsNullOrEmpty(habit.Icon))
+                    {
+                        <span class="text-base md:text-xl shrink-0">@habit.Icon</span>
+                    }
+                    <span class="text-xs font-bold @cardText truncate">@habit.Name</span>
+                </div>
+                <div class="text-sm md:text-2xl text-center font-bold @cardText">@habit.LogCount</div>
+                <div class="text-[11px] text-right text-gray-400">logs</div>
+            </div>
+        }
+    }
+</div>
+
 <!-- Main content: two columns -->
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-2 md:gap-4">
 
@@ -227,6 +259,12 @@
     private Dictionary<string, GoldPriceResponse?> _goldPrices = new();
     private bool _goldPricesLoading = true;
 
+    private List<HabitItemResponse> _habits = [];
+    private bool _habitsLoading = true;
+
+    private static readonly string[] HabitCardBgColors = ["bg-indigo-50", "bg-amber-50", "bg-green-50", "bg-rose-50", "bg-purple-50", "bg-teal-50", "bg-blue-50", "bg-orange-50"];
+    private static readonly string[] HabitCardTextColors = ["text-indigo-700", "text-amber-700", "text-green-700", "text-rose-700", "text-purple-700", "text-teal-700", "text-blue-700", "text-orange-700"];
+
     private static readonly string[] PieColors = ["#6366f1", "#8b5cf6", "#ec4899", "#f43f5e", "#f97316", "#eab308", "#22c55e", "#06b6d4", "#3b82f6", "#a855f7"];
 
     private record PieSlice(string Name, double Fraction, string Color);
@@ -234,7 +272,15 @@
     protected override async Task OnInitializedAsync()
     {
         await Task.Yield();
-        await Task.WhenAll(LoadStatsAsync(), LoadWalletsAsync(), LoadDefaultTodosAsync(), LoadGoldPricesAsync());
+        await Task.WhenAll(LoadStatsAsync(), LoadWalletsAsync(), LoadDefaultTodosAsync(), LoadGoldPricesAsync(), LoadHabitsAsync());
+    }
+
+    private async Task LoadHabitsAsync()
+    {
+        _habitsLoading = true;
+        var (data, _) = await Api.GetHabitsAsync();
+        _habits = data ?? [];
+        _habitsLoading = false;
     }
 
     private async Task LoadGoldPricesAsync()

--- a/SourceBase.Web/Services/ApiHttpClient.cs
+++ b/SourceBase.Web/Services/ApiHttpClient.cs
@@ -459,4 +459,4 @@ public sealed record IconResponse(Guid Id, string Value, string Name, string Gro
 public sealed record IconUploadUrlResponse(string UploadUrl, string IconUrl, string ContentType);
 public sealed record GoldPriceResponse(Guid Id, string Source, decimal BuyPrice, decimal SellPrice, DateTime RecordedAt);
 public sealed record HabitLogResponse(Guid Id, string? HabitId, string? HabitName, string Action, DateTime OccurredAt, DateTime? CreatedOn);
-public sealed record HabitItemResponse(Guid Id, string Name, string? Icon, bool IsSystem);
+public sealed record HabitItemResponse(Guid Id, string Name, string? Icon, bool IsSystem, int LogCount);


### PR DESCRIPTION
## Summary
Add habit log count tracking and display habits with their log counts on the home dashboard in a responsive card grid.

## Key Changes

**Backend (Application)**
- Updated `HabitResponse` record to include `LogCount` field
- Enhanced `GetHabitsHandler` to query and aggregate habit log counts from the database
- Results now ordered by log count (descending) to highlight most-logged habits

**Frontend (Web)**
- Added habits card grid section to Home.razor dashboard above main content
- Displays habit name, icon, and log count in colored cards with responsive layout (3 cols mobile, 5 cols desktop)
- Includes loading and empty states
- Implemented color rotation using `HabitCardBgColors` and `HabitCardTextColors` arrays for visual variety
- Integrated `LoadHabitsAsync()` into component initialization

**API Client**
- Updated `HabitItemResponse` record to include `LogCount` field

## Implementation Details
- Habits are fetched and loaded in parallel with other dashboard data during component initialization
- Card styling uses Tailwind CSS with responsive padding and text sizing (mobile-first approach)
- Log counts are aggregated server-side using EF Core `GroupBy` for efficiency
- Empty state displays "No habits yet" message when user has no habits

https://claude.ai/code/session_019eaUhw2CsZ4wR5ntTYKLT6