### PR TITLE
Make habit logs table fit on mobile (320px) - always show 7 day columns

### DIFF
--- a/SourceBase.Web/Pages/HabitLogs/HabitLogs.razor
+++ b/SourceBase.Web/Pages/HabitLogs/HabitLogs.razor
@@ -61,20 +61,20 @@ else if (_error is not null)
 }
 else
 {
-    <!-- Calendar — 30-min time-block grid, horizontal scroll on mobile S/M -->
-    <div class="overflow-x-auto rounded-xl border border-gray-200 shadow-sm">
-        <div id="@GridScrollId" class="min-w-160 max-h-[70vh] overflow-y-auto">
+    <!-- Calendar — 30-min time-block grid, always shows 7 days -->
+    <div class="rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <div id="@GridScrollId" class="max-h-[70vh] overflow-y-auto">
 
             <!-- Day header row -->
-            <div class="grid grid-cols-[52px_repeat(7,1fr)] bg-gray-50 border-b border-gray-200 sticky top-0 z-10">
+            <div class="grid grid-cols-[32px_repeat(7,1fr)] bg-gray-50 border-b border-gray-200 sticky top-0 z-10">
                 <div class="border-r border-gray-200"></div>
                 @for (var d = 0; d < 7; d++)
                 {
                     var day = WeekStart.AddDays(d);
                     var isToday = day.Date == DateTime.Today;
-                    <div class="flex flex-col items-center py-2 border-r last:border-r-0 border-gray-200 @(isToday ? "bg-indigo-50" : "")">
-                        <span class="text-[11px] font-semibold uppercase tracking-wide @(isToday ? "text-indigo-500" : "text-gray-400")">@day.ToString("ddd")</span>
-                        <span class="text-base font-bold mt-0.5 @(isToday ? "text-indigo-700" : "text-gray-700")">@day.Day</span>
+                    <div class="flex flex-col items-center justify-center py-1.5 border-r last:border-r-0 border-gray-200 @(isToday ? "bg-indigo-50" : "")">
+                        <span class="text-[9px] font-semibold uppercase tracking-wide @(isToday ? "text-indigo-500" : "text-gray-400")">@day.ToString("ddd")</span>
+                        <span class="text-xs font-bold mt-0.5 @(isToday ? "text-indigo-700" : "text-gray-700")">@day.Day</span>
                     </div>
                 }
             </div>
@@ -85,8 +85,8 @@ else
                 {
                     var slotIndex = slot;
                     var isHour = slotIndex % 2 == 0;
-                    <div id="@(slotIndex == DefaultStartSlot ? DefaultStartRowId : null)" class="grid grid-cols-[52px_repeat(7,1fr)] @(isHour ? "border-t border-gray-200" : "border-t border-gray-100")">
-                        <div class="flex items-start justify-end pr-1.5 pt-0.5 border-r border-gray-200 text-[10px] text-gray-400 select-none">
+                    <div id="@(slotIndex == DefaultStartSlot ? DefaultStartRowId : null)" class="grid grid-cols-[32px_repeat(7,1fr)] @(isHour ? "border-t border-gray-200" : "border-t border-gray-100")">
+                        <div class="flex items-start justify-end pr-0.5 pt-0.5 border-r border-gray-200 text-[8px] text-gray-400 select-none leading-none">
                             @if (isHour)
                             {
                                 @SlotLabel(slotIndex)
@@ -97,11 +97,11 @@ else
                             var day = WeekStart.AddDays(d);
                             var isToday = day.Date == DateTime.Today;
                             var entries = LogsForSlot(day, slotIndex);
-                            <div class="min-h-8 px-0.5 py-0.5 border-r last:border-r-0 border-gray-100 @(isToday ? "bg-indigo-50/20" : "")">
+                            <div class="min-h-6 px-0.5 py-0.5 border-r last:border-r-0 border-gray-100 @(isToday ? "bg-indigo-50/20" : "")">
                                 <div class="flex flex-wrap gap-0.5">
                                     @foreach (var log in entries.Where(l => l.Action == "HabitStarted"))
                                     {
-                                        <span class="inline-flex items-center justify-center w-6 h-6 rounded-md border text-base leading-none @EntryClass(log.Action)" title="@EntryTitle(log)">@EntryIcon(log)</span>
+                                        <span class="inline-flex items-center justify-center w-5 h-5 rounded-sm border text-xs leading-none @EntryClass(log.Action)" title="@EntryTitle(log)">@EntryIcon(log)</span>
                                     }
                                 </div>
                             </div>


### PR DESCRIPTION
- Reduced time column width from 52px to 32px
- Reduced day header height and font sizes (day name: 9px, day number: xs)
- Reduced time label font to 8px
- Reduced habit entry badges from 6x6 to 5x5
- Changed min row height from 8 to 6 for more compact grid
- Removed horizontal scroll - calendar always fits within container width