### PR TITLE
Hide project text on mobile, show only on md screens and larger

### DIFF
--- a/SourceBase.Web/Pages/TimeSheets/TimeSheets.razor
+++ b/SourceBase.Web/Pages/TimeSheets/TimeSheets.razor
@@ -47,7 +47,7 @@
                             @if (summary is not null)
                             {
                                 <span class="text-xs mt-0.5 font-medium leading-none">@summary.TotalHours h</span>
-                                <span class="text-xs leading-none opacity-75 truncate w-full text-center px-0.5">@string.Join(", ", summary.Projects)</span>
+                                <span class="hidden md:block text-xs leading-none opacity-75 truncate w-full text-center px-0.5">@string.Join(", ", summary.Projects)</span>
                             }
                             @if (IsSos(date, summary))
                             {


### PR DESCRIPTION
Hide the projects summary text in the timesheet calendar on mobile (320px) viewports
and display it on medium (768px) and larger screens to improve readability on small
screens. Uses Tailwind's 'hidden md:block' responsive classes.